### PR TITLE
Feature/calendar layout

### DIFF
--- a/assets/templates/calendar.tmpl
+++ b/assets/templates/calendar.tmpl
@@ -1,6 +1,6 @@
 <div class="ons-page__container ons-container">
   <div class="ons-grid ons-u-ml-no">
-    <h1 class="ons-u-fs-xxxl ons-u-mt-s">{{ .Page.Metadata.Title }}</h1>
+    <h1 class="ons-u-fs-xxxl ons-u-mt-m ons-u-mb-xl">{{ .Page.Metadata.Title }}</h1>
 
     <!-- Left column -->
     <div class="ons-grid__col ons-col-4@m ons-u-p-no">
@@ -8,7 +8,7 @@
     </div>
 
     <!-- Right column -->
-    <div class="ons-grid__col ons-col-8@m">
+    <div class="ons-grid__col ons-col-8@m ons-u-p-no@xxs@m">
       {{ template "partials/calendar/items" . }}
     </div>
   </div>

--- a/assets/templates/calendar.tmpl
+++ b/assets/templates/calendar.tmpl
@@ -1,4 +1,4 @@
-<div class="ons-page__container ons-container">
+<div class="ons-page__container ons-container release-calendar">
   <div class="ons-grid ons-u-ml-no">
     <h1 class="ons-u-fs-xxxl ons-u-mt-m ons-u-mb-xl">{{ .Page.Metadata.Title }}</h1>
 

--- a/assets/templates/partials/calendar/filters.tmpl
+++ b/assets/templates/partials/calendar/filters.tmpl
@@ -1,54 +1,58 @@
-<div class="ons-accordion ons-pl-grid-col">
-  <div class="ons-u-fs-r--b">Filter results</div>
-
-  <div
-    class="ons-collapsible ons-js-collapsible ons-collapsible--accordion"
-    data-btn-close="Hide"
-    data-group="accordion"
-    data-open="true"
-  >
-    <div class="ons-collapsible__heading ons-js-collapsible-heading">
-      <div class="ons-collapsible__controls">
-        <h2 class="ons-collapsible__title">Release type</h2>
-        {{ template "icons/collapsible" . }}
-      </div>
-    </div>
-    <div class="ons-collapsible__content ons-js-collapsible-content ons-u-mb-s">
-      {{ template "partials/calendar/filter/release-type" . }}
-    </div>
+<div class="ons-pl-grid-col">
+  <div class="ons-u-fs-r--b ons-u-mb-s obs-u-bb" style="line-height: 1.3rem; padding: 0.39rem 2rem 0.39rem 0.5rem;">
+    <div style=" margin-top: 1px; margin-bottom: 1px">Filter results</div>
   </div>
 
-  <div
-    class="ons-collapsible ons-js-collapsible ons-collapsible--accordion"
-    data-btn-close="Hide"
-    data-group="accordion"
-    data-open="true"
-  >
-    <div class="ons-collapsible__heading ons-js-collapsible-heading">
-      <div class="ons-collapsible__controls">
-        <h2 class="ons-collapsible__title">Search</h2>
-        {{ template "icons/collapsible" . }}
+  <div class="ons-accordion">
+    <div
+      class="ons-collapsible ons-js-collapsible ons-collapsible--accordion"
+      data-btn-close="Hide"
+      data-group="accordion"
+      data-open="true"
+    >
+      <div class="ons-collapsible__heading ons-js-collapsible-heading">
+        <div class="ons-collapsible__controls">
+          <h2 class="ons-collapsible__title">Release type</h2>
+          {{ template "icons/collapsible" . }}
+        </div>
+      </div>
+      <div class="ons-collapsible__content ons-js-collapsible-content ons-u-mb-s">
+        {{ template "partials/calendar/filter/release-type" . }}
       </div>
     </div>
-    <div class="ons-collapsible__content ons-js-collapsible-content ons-u-mb-s">
-      {{ template "partials/calendar/filter/search-keywords" . }}
-    </div>
-  </div>
 
-  <div
-    class="ons-collapsible ons-js-collapsible ons-collapsible--accordion"
-    data-btn-close="Hide"
-    data-group="accordion"
-    data-open="true"
-  >
-    <div class="ons-collapsible__heading ons-js-collapsible-heading">
-      <div class="ons-collapsible__controls">
-        <h2 class="ons-collapsible__title">Date</h2>
-        {{ template "icons/collapsible" . }}
+    <div
+      class="ons-collapsible ons-js-collapsible ons-collapsible--accordion"
+      data-btn-close="Hide"
+      data-group="accordion"
+      data-open="true"
+    >
+      <div class="ons-collapsible__heading ons-js-collapsible-heading">
+        <div class="ons-collapsible__controls">
+          <h2 class="ons-collapsible__title">Search</h2>
+          {{ template "icons/collapsible" . }}
+        </div>
+      </div>
+      <div class="ons-collapsible__content ons-js-collapsible-content ons-u-mb-s">
+        {{ template "partials/calendar/filter/search-keywords" . }}
       </div>
     </div>
-    <div class="ons-collapsible__content ons-js-collapsible-content">
-      {{ template "partials/calendar/filter/date" . }}
+
+    <div
+      class="ons-collapsible ons-js-collapsible ons-collapsible--accordion"
+      data-btn-close="Hide"
+      data-group="accordion"
+      data-open="true"
+    >
+      <div class="ons-collapsible__heading ons-js-collapsible-heading">
+        <div class="ons-collapsible__controls">
+          <h2 class="ons-collapsible__title">Date</h2>
+          {{ template "icons/collapsible" . }}
+        </div>
+      </div>
+      <div class="ons-collapsible__content ons-js-collapsible-content">
+        {{ template "partials/calendar/filter/date" . }}
+      </div>
     </div>
   </div>
 </div>

--- a/assets/templates/partials/calendar/filters.tmpl
+++ b/assets/templates/partials/calendar/filters.tmpl
@@ -1,6 +1,6 @@
-<div class="ons-pl-grid-col">
-  <div class="ons-u-fs-r--b ons-u-mb-s obs-u-bb" style="line-height: 1.3rem; padding: 0.39rem 2rem 0.39rem 0.5rem;">
-    <div style=" margin-top: 1px; margin-bottom: 1px">Filter results</div>
+<div class="ons-pl-grid-col release-calendar__filters">
+  <div class="ons-u-fs-r--b release-calendar__filters__heading">
+    <div class="release-calendar__filters__heading--margin-one-fix">Filter results</div>
   </div>
 
   <div class="ons-accordion">

--- a/assets/templates/partials/calendar/items/consumer-actions.tmpl
+++ b/assets/templates/partials/calendar/items/consumer-actions.tmpl
@@ -1,14 +1,16 @@
-<ul class="ons-list ons-list--bare ons-list--inline ons-u-fs-s ons-u-mt-s ons-u-mb-s ons-u-ml-no ons-u-ml-no">
-  <li class="ons-list__item">
-    <span class="ons-list__prefix" aria-hidden="true">&#x1F4C4;</span>
-    <a href="#" class="ons-list__link ons-u-td-no">RSS feed</a>
-  </li>
-  <li class="ons-list__item">
-    <span class="ons-list__prefix" aria-hidden="true">&#x26A0;</span>
-    <a href="#" class="ons-list__link ons-u-td-no">Email alerts</a>
-  </li>
-  <li class="ons-list__item">
-    <span class="ons-list__prefix" aria-hidden="true">&#x1F4C5;</span>
-    <a href="#" class="ons-list__link ons-u-td-no">Add to your calendar (ICS)</a>
-  </li>
-</ul>
+<div class="ons-u-bt ons-u-mt-l ons-u-mb-l">
+  <ul class="ons-list ons-list--bare ons-list--inline@m ons-u-fs-s ons-u-mt-s ons-u-mb-s ons-u-ml-no ons-u-mr-no">
+    <li class="ons-list__item">
+      <span class="ons-list__prefix" aria-hidden="true">&#x1F4C4;</span>
+      <a href="#" class="ons-list__link ons-u-td-no">RSS feed</a>
+    </li>
+    <li class="ons-list__item">
+      <span class="ons-list__prefix" aria-hidden="true">&#x26A0;</span>
+      <a href="#" class="ons-list__link ons-u-td-no">Email alerts</a>
+    </li>
+    <li class="ons-list__item ons-u-mr-no">
+      <span class="ons-list__prefix" aria-hidden="true">&#x1F4C5;</span>
+      <a href="#" class="ons-list__link ons-u-td-no ons-u-mr-no">Add to your calendar (ICS)</a>
+    </li>
+  </ul>
+</div>

--- a/assets/templates/partials/calendar/items/list.tmpl
+++ b/assets/templates/partials/calendar/items/list.tmpl
@@ -1,4 +1,4 @@
-<ol class="ons-list ons-list--bare">
+<ol class="ons-list ons-list--bare ons-u-bt">
   {{range .CalendarPagination.CalendarItem }}
     <li class="ons-list__item ons-u-mt-l">
       <a

--- a/assets/templates/partials/calendar/items/sort-by.tmpl
+++ b/assets/templates/partials/calendar/items/sort-by.tmpl
@@ -9,7 +9,7 @@
     The Sort button is hidden when JavaScript is enabled.
 */}}
 
-<form>
+<form class="ons-u-pb-s">
   {{/* Include all other page settings in the form submission */}}
   {{ template "partials/calendar/hidden-inputs/release-types" . }}
   {{ template "partials/calendar/hidden-inputs/keywords" . }}

--- a/config/config.go
+++ b/config/config.go
@@ -33,7 +33,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/f34f3ac"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/42275e1"
 	}
 
 	return cfg, nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,7 +22,7 @@ func TestConfig(t *testing.T) {
 			Convey("Then the values should be set to the expected defaults", func() {
 				So(cfg.Debug, ShouldBeFalse)
 				So(cfg.BindAddr, ShouldEqual, ":27700")
-				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/f34f3ac")
+				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/42275e1")
 				So(cfg.SupportedLanguages, ShouldResemble, []string{"en", "cy"})
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)


### PR DESCRIPTION
### What

## Layout changes to the Release Calendar

- Correctly align the headers of the left and right columns in the desktop view:

<img width="1011" alt="release-calendar-headings" src="https://user-images.githubusercontent.com/912770/159045898-f6381273-5a13-45bb-81a7-4c9a0d8d8b28.png">

- Render action links on one row on desktop and tablet, and in one column on mobile:

Desktop:
<img width="1016" alt="Screenshot 2022-03-18 at 16 43 40" src="https://user-images.githubusercontent.com/912770/159046599-8c4d6407-73da-4110-b9cd-36ff7ff80bb3.png">

Tablet:
<img width="401" alt="Screenshot 2022-03-18 at 16 44 02" src="https://user-images.githubusercontent.com/912770/159046608-2fde1b1a-696b-46fc-869b-354ee5f9881b.png">

Mobile:
<img width="410" alt="Screenshot 2022-03-18 at 16 44 12" src="https://user-images.githubusercontent.com/912770/159046612-5afdf21e-a9e7-4167-a8f1-7518a818b539.png">

- On mobile, the left margin of the filter column and the results column are now identical:

![Screenshot 2022-03-18 at 16 48 47](https://user-images.githubusercontent.com/912770/159047081-a2b09a73-f440-4f3f-af07-5599aef380c5.png)


### How to review

- Run dp-design-system
- Run dp-frontend-release-calendar
- View http://localhost:27700/calendarsample in desktop, tablet, and mobile

### Who can review

Front end / design system developers
