### PR TITLE
Results per page selector removed from Release Calendar

### DIFF
--- a/assets/templates/partials/calendar/items/pagination.tmpl
+++ b/assets/templates/partials/calendar/items/pagination.tmpl
@@ -26,12 +26,4 @@
       </li>
     </ul>
   </nav>
-
-  <div class="ons-field ons-field--inline">
-    <label class="ons-label" for="select">Results per page</label>
-    <select id="select" name="select" class="ons-input ons-input--select ons-u-wa--@xxs">
-      <option value="page-count-10" selected>10</option>
-      <option value="page-count-25">25</option>
-    </select>
-  </div>
 </div>


### PR DESCRIPTION
### What

Results per page selector removed from Release Calendar in keeping with v2 design in Figma.

### How to review

Verify that the selector has gone.

### Who can review

Anyone
