### PR TITLE
Bump dp-renderer to v1.23.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.104.0
 	github.com/ONSdigital/dp-healthcheck v1.2.3
 	github.com/ONSdigital/dp-net/v2 v2.0.0
-	github.com/ONSdigital/dp-renderer v1.23.0
+	github.com/ONSdigital/dp-renderer v1.23.2
 	github.com/ONSdigital/log.go/v2 v2.1.0
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/ONSdigital/dp-renderer v1.22.0 h1:OxA5O60YL7XcxdcDz74hYqcrF1XgZKiVHtK
 github.com/ONSdigital/dp-renderer v1.22.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/dp-renderer v1.23.0 h1:KX6kaz/xzuLI2/Tti+zoKPhLenbNUAaxO7Ace1jHaF4=
 github.com/ONSdigital/dp-renderer v1.23.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
+github.com/ONSdigital/dp-renderer v1.23.2 h1:CinHL361CcJSkf/3uQy2hYCsZFVVWcyJDomDF1m0DJk=
+github.com/ONSdigital/dp-renderer v1.23.2/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=


### PR DESCRIPTION
### What

Bump dp-renderer to v1.23.2 to import the temporary Welsh translations for pagination.

### How to review

- Run `dp-design-system` in a separate tab with `make debug`
- In `mapper.go` force the language to Welsh with `calendar.Language = "cy"` in the calendar release sample
- Run the frontend with `make debug`
- Open `http://localhost:27700/calendarsample` in your browser and page should render instead of getting a template error due to missing Welsh translations in the pagination component.

### Who can review

Anyone
