### PR TITLE
Use latest sort option wording in release calendar sample

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -613,20 +613,24 @@ func CreateCalendar(_ context.Context, basePage coreModel.Page, _ config.Config)
 		Mode: "alphabetical-az",
 		Options: []model.SortOption{
 			{
-				Label: "Date (Newest)",
+				Label: "Date (newest)",
 				Value: "date-newest",
 			},
 			{
-				Label: "Date (Oldest)",
+				Label: "Date (oldest)",
 				Value: "date-oldest",
 			},
 			{
-				Label: "Alphabetical (A-Z)",
+				Label: "Alphabetical (A to Z)",
 				Value: "alphabetical-az",
 			},
 			{
-				Label: "Alphabetical (Z-A)",
+				Label: "Alphabetical (Z to A)",
 				Value: "alphabetical-za",
+			},
+			{
+				Label: "Relevance",
+				Value: "relevance",
 			},
 		},
 	}


### PR DESCRIPTION
### What

Updated the sort options to reflect the wording in the current design

<img width="326" alt="Screenshot 2022-04-05 at 17 29 26" src="https://user-images.githubusercontent.com/912770/161802446-9a96f15d-d3a5-4d4c-93f4-ad85074a2933.png">

### How to review

Sanity check

### Who can review

Anyone
