### PR TITLE
Allow highlighted keywords to render correctly in Release Calendar entry titles

### DIFF
--- a/assets/templates/partials/calendar/items/list.tmpl
+++ b/assets/templates/partials/calendar/items/list.tmpl
@@ -1,3 +1,9 @@
+{{/*
+  .Description.Title is piped through safeHTML to allow keywords to be
+  highlighted by the search engine, which wraps them in an ONS Design System
+  tag designed for the purpose:
+    <em class="ons-highlight">keyword</em>
+*/}}
 <ol class="ons-list ons-list--bare ons-u-bt">
   {{range .Entries }}
     <li class="ons-list__item ons-u-mt-l">
@@ -5,7 +11,7 @@
         href="{{ .URI }}"
         class="ons-u-fs-l ons-u-td-no ons-u-d-b"
       >
-        {{ .Description.Title }}
+        {{- .Description.Title | safeHTML -}}
       </a>
       <div class="ons-u-mt-s">
         <span class="ons-u-fs-r--b">Release date:</span>


### PR DESCRIPTION
### What

Elastic Search has been configured to wrap keywords found in a search in the appropriate ONS Design System tag:

```
<em class="ons-highlight">keyword</em>
```

Modifying the partial to allow this HTML through un-escaped allows the browser to highlight the keyword as intended by this markup.

### How to review

- Run dp-design-system in a separate terminal with `make debug`
- Run the frontend with `make debug`
- Visit the http://localhost:27700/releasecalendar
- Search for a word under 'Search keywords'
- Observe highlighted word in calendar entry titles

### Who can review

Frontend / ONS Design System developers
