### PR TITLE
Radio buttons share single release-type parameter name

### DIFF
--- a/assets/templates/partials/calendar/filter/release-type.tmpl
+++ b/assets/templates/partials/calendar/filter/release-type.tmpl
@@ -15,6 +15,7 @@
                     {{ template "partials/calendar/inputs/radio-inputs" . }}
                   </span>
                 </span>
+                <br>
             {{ end }}
             {{ with index .ReleaseTypes "type-upcoming" }}
                 <span class="ons-radios__item ons-radios__item--no-border">

--- a/assets/templates/partials/calendar/hidden-inputs/keywords.tmpl
+++ b/assets/templates/partials/calendar/hidden-inputs/keywords.tmpl
@@ -1,3 +1,3 @@
-{{ if .Keywords }}
+{{ if and .KeywordSearch .KeywordSearch.SearchTerm }}
   <input type="hidden" name="keywords" value="{{ .KeywordSearch.SearchTerm }}">
 {{ end }}

--- a/assets/templates/partials/calendar/hidden-inputs/release-types.tmpl
+++ b/assets/templates/partials/calendar/hidden-inputs/release-types.tmpl
@@ -1,6 +1,6 @@
 {{ range $type, $value := .ReleaseTypes }}
   {{ if $value.Checked }}
-    <input type="hidden" name="{{ $type }}" value="true">
+    <input type="hidden" name="{{ $value.Name }}" value="{{ $value.Value }}">
   {{ end }}
 
   {{ range $subType, $subValue := $value.SubTypes }}

--- a/assets/templates/partials/calendar/inputs/checkbox-inputs.tmpl
+++ b/assets/templates/partials/calendar/inputs/checkbox-inputs.tmpl
@@ -1,12 +1,16 @@
-<input type="checkbox"
-        id="{{ .Id }}"
-        class="ons-checkbox__input ons-js-checkbox"
-        name="{{ .Name }}"
-        value="true"
-        {{ if .Checked }}
-            checked
-        {{ end }}
+<input
+  type="checkbox"
+  id="{{ .Id }}"
+  class="ons-checkbox__input ons-js-checkbox"
+  name="{{ .Name }}"
+  value="true"
+  {{ if .Checked }}
+    checked
+  {{ end }}
 >
-<label class="ons-checkbox__label" for="{{.Id}}">
-    {{ .Label }} ({{ .Count }})
+<label
+  class="ons-checkbox__label"
+  for="{{.Id}}"
+>
+  {{ .Label }} ({{ .Count }})
 </label>

--- a/assets/templates/partials/calendar/inputs/radio-inputs.tmpl
+++ b/assets/templates/partials/calendar/inputs/radio-inputs.tmpl
@@ -1,11 +1,17 @@
-<input type="radio"
-       id="{{ .Id }}"
-       name="{{ .Name }}"
-       class="ons-radio__input ons-js-radio"
-       value="true"
-        {{ if .Checked }}
-            checked
-        {{ end }}/>
-<label class="ons-radio__label" for="{{.Id}}" id="{{.Id}}-label">
-    {{ .Label }} ({{ .Count }})
+<input
+  type="radio"
+  id="{{ .Id }}"
+  name="{{ .Name }}"
+  class="ons-radio__input ons-js-radio"
+  value="{{ .Value }}"
+  {{ if .Checked }}
+    checked
+  {{ end }}
+>
+<label
+  class="ons-radio__label"
+  for="{{.Id}}"
+  id="{{.Id}}-label"
+>
+  {{ .Label }} ({{ .Count }})
 </label>

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -585,14 +585,16 @@ func CreateCalendar(_ context.Context, basePage coreModel.Page, _ config.Config)
 
 	calendar.ReleaseTypes = map[string]model.ReleaseType{
 		"type-published": {
-			Name:    "type-published",
+			Name:    "release-type",
+			Value:   "type-published",
 			Id:      "release-type-published",
 			Label:   "Published",
 			Checked: false,
 			Count:   450,
 		},
 		"type-upcoming": {
-			Name:    "type-upcoming",
+			Name:    "release-type",
+			Value:   "type-upcoming",
 			Id:      "release-type-upcoming",
 			Label:   "Upcoming",
 			Checked: true,
@@ -622,9 +624,10 @@ func CreateCalendar(_ context.Context, basePage coreModel.Page, _ config.Config)
 			},
 		},
 		"type-cancelled": {
-			Label:   "Cancelled",
-			Name:    "type-cancelled",
+			Name:    "release-type",
+			Value:   "type-cancelled",
 			Id:      "release-type-cancelled",
+			Label:   "Cancelled",
 			Checked: true,
 			Count:   0,
 		},
@@ -708,26 +711,38 @@ func mapReleases(params queryparams.ValidatedParams, response search.ReleaseResp
 	checkFlag := func(flag bool) bool { return flag }
 	return map[string]model.ReleaseType{
 		"type-published": {
+			Name:    "release-type",
+			Value:   "type-published",
+			Id:      "release-type-published",
 			Label:   "Published",
 			Checked: checkType(params.ReleaseType, queryparams.Published),
 			Count:   response.Breakdown.Published,
 		},
 		"type-upcoming": {
+			Name:    "release-type",
+			Value:   "type-upcoming",
+			Id:      "release-type-upcoming",
 			Label:   "Upcoming",
 			Checked: checkType(params.ReleaseType, queryparams.Upcoming),
 			Count:   response.Breakdown.Provisional + response.Breakdown.Confirmed + response.Breakdown.Postponed,
 			SubTypes: map[string]model.ReleaseType{
 				"subtype-confirmed": {
+					Name:    "subtype-confirmed",
+					Id:      "release-subtype-confirmed",
 					Label:   "Confirmed",
 					Checked: checkFlag(params.Confirmed),
 					Count:   response.Breakdown.Confirmed,
 				},
 				"subtype-provisional": {
+					Name:    "subtype-provisional",
+					Id:      "release-subtype-provisional",
 					Label:   "Provisional",
 					Checked: checkFlag(params.Provisional),
 					Count:   response.Breakdown.Provisional,
 				},
 				"subtype-postponed": {
+					Name:    "subtype-postponed",
+					Id:      "release-subtype-postponed",
 					Label:   "Postponed",
 					Checked: checkFlag(params.Postponed),
 					Count:   response.Breakdown.Postponed,
@@ -735,6 +750,9 @@ func mapReleases(params queryparams.ValidatedParams, response search.ReleaseResp
 			},
 		},
 		"type-cancelled": {
+			Name:    "release-type",
+			Value:   "type-cancelled",
+			Id:      "release-type-cancelled",
 			Label:   "Cancelled",
 			Checked: checkType(params.ReleaseType, queryparams.Cancelled),
 			Count:   response.Breakdown.Cancelled,

--- a/model/calendar.go
+++ b/model/calendar.go
@@ -15,7 +15,8 @@ type ReleaseType struct {
 	Id       string                 `json:"id"`
 	Label    string                 `json:"label"`
 	Name     string                 `json:"name"`
-	Checked  bool                   `json:"value"`
+	Value    string                 `json:"value"`
+	Checked  bool                   `json:"checked"`
 	Count    int                    `json:"count"`
 	SubTypes map[string]ReleaseType `json:"sub_types"`
 }


### PR DESCRIPTION
### What

Filtering by release type using the radio buttons now uses a single, shared parameter called `release-type` to pass the chosen option to the server.

### How to review

Radio button categories should now be mutually exclusive.

### Who can review

Anyone
