### PR TITLE
Associate presence of search keyword with availability of relevance sort option

### DIFF
--- a/assets/templates/partials/calendar/filter/search-keywords.tmpl
+++ b/assets/templates/partials/calendar/filter/search-keywords.tmpl
@@ -5,9 +5,15 @@
 >
   {{/* Include all other page settings in the form submission */}}
   {{ template "partials/calendar/hidden-inputs/release-types" . }}
-  {{ template "partials/calendar/hidden-inputs/sort-mode" . }}
   {{ template "partials/calendar/hidden-inputs/before-date" . }}
   {{ template "partials/calendar/hidden-inputs/after-date" . }}
+
+  {{/*
+    Force the sort order to 'relevance' when submitting keywords.
+    Empty keywords will be detected by the backend and ignore 'relevance'
+    in favour of a more appropriate default.
+  */}}
+  <input type="hidden" name="sort" value="relevance">
 
   {{ template "partials/compact-search" .KeywordSearch }}
 </form>

--- a/assets/templates/partials/calendar/items/sort-by.tmpl
+++ b/assets/templates/partials/calendar/items/sort-by.tmpl
@@ -31,8 +31,10 @@
         <option
           value="{{ .Value }}"
           {{ if eq .Value $sortMode }}selected{{ end }}
+          {{ if .Disabled }}disabled{{ end }}
         >
           {{- localise .LocaleKey $.Language .Plural -}}
+
         </option>
       {{ end }}
     </select>

--- a/assets/templates/partials/calendar/items/sort-by.tmpl
+++ b/assets/templates/partials/calendar/items/sort-by.tmpl
@@ -34,7 +34,6 @@
           {{ if .Disabled }}disabled{{ end }}
         >
           {{- localise .LocaleKey $.Language .Plural -}}
-
         </option>
       {{ end }}
     </select>

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -100,28 +100,19 @@ func releaseCalendar(w http.ResponseWriter, req *http.Request, userAccessToken, 
 	params.Set(queryparams.DateTo, toDate.String())
 	validatedParams.BeforeDate = toDate
 
-	defaultSort := queryparams.MustParseSort(cfg.DefaultSort)
-	sort, err := queryparams.GetSortOrder(ctx, params, defaultSort)
+	sort, err := queryparams.GetSortOrder(ctx, params, queryparams.MustParseSort(cfg.DefaultSort))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	params.Set(queryparams.SortName, sort.BackendString())
+	validatedParams.Sort = sort
 
 	keywords, err := queryparams.GetKeywords(ctx, params, "")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-
-	// The frontend keyword search forces the sort order to 'Relevance'
-	// When keywords are empty in this case, force the sort order back to the default.
-	if keywords == "" && sort.String() == queryparams.Relevance.String() {
-		sort = defaultSort
-	}
-
-	params.Set(queryparams.SortName, sort.BackendString())
-	validatedParams.Sort = sort
-
 	params.Set(queryparams.Keywords, keywords)
 	validatedParams.Keywords = keywords
 	params.Set(queryparams.Query, keywords)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -100,19 +100,28 @@ func releaseCalendar(w http.ResponseWriter, req *http.Request, userAccessToken, 
 	params.Set(queryparams.DateTo, toDate.String())
 	validatedParams.BeforeDate = toDate
 
-	sort, err := queryparams.GetSortOrder(ctx, params, queryparams.MustParseSort(cfg.DefaultSort))
+	defaultSort := queryparams.MustParseSort(cfg.DefaultSort)
+	sort, err := queryparams.GetSortOrder(ctx, params, defaultSort)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	params.Set(queryparams.SortName, sort.BackendString())
-	validatedParams.Sort = sort
 
 	keywords, err := queryparams.GetKeywords(ctx, params, "")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+
+	// The frontend keyword search forces the sort order to 'Relevance'
+	// When keywords are empty in this case, force the sort order back to the default.
+	if keywords == "" && sort.String() == queryparams.Relevance.String() {
+		sort = defaultSort
+	}
+
+	params.Set(queryparams.SortName, sort.BackendString())
+	validatedParams.Sort = sort
+
 	params.Set(queryparams.Keywords, keywords)
 	validatedParams.Keywords = keywords
 	params.Set(queryparams.Query, keywords)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -105,7 +105,7 @@ func releaseCalendar(w http.ResponseWriter, req *http.Request, userAccessToken, 
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	params.Set(queryparams.SortName, sort.OptionString())
+	params.Set(queryparams.SortName, sort.BackendString())
 	validatedParams.Sort = sort
 
 	keywords, err := queryparams.GetKeywords(ctx, params, "")

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -265,6 +265,24 @@ func mapLink(links []releasecalendar.Link) []model.Link {
 	return res
 }
 
+func associateSortRelevanceWithKeywordPresence(sortOptions []queryparams.SortOption, searchTerm string) []queryparams.SortOption {
+	var options []queryparams.SortOption
+
+	for _, option := range sortOptions {
+		if option.Value == "relevance" {
+			if searchTerm == "" {
+				option.Disabled = true
+			} else {
+				option.Disabled = false
+			}
+		}
+
+		options = append(options, option)
+	}
+
+	return options
+}
+
 func CreateReleaseCalendar(basePage coreModel.Page, params queryparams.ValidatedParams, response search.ReleaseResponse, cfg config.Config) model.Calendar {
 	calendar := model.Calendar{
 		Page: basePage,
@@ -278,7 +296,11 @@ func CreateReleaseCalendar(basePage coreModel.Page, params queryparams.Validated
 		LabelLocaliseKey: "ReleaseCalendarPageSearchKeywords",
 		SearchTerm:       params.Keywords,
 	}
-	calendar.Sort = model.Sort{Mode: params.Sort.String(), Options: queryparams.SortOptions}
+
+	calendar.Sort = model.Sort{
+		Mode:    params.Sort.String(),
+		Options: associateSortRelevanceWithKeywordPresence(queryparams.SortOptions, calendar.KeywordSearch.SearchTerm),
+	}
 
 	calendar.AfterDate = coreModel.InputDate{
 		Language:        calendar.Language,

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -265,24 +265,6 @@ func mapLink(links []releasecalendar.Link) []model.Link {
 	return res
 }
 
-func associateSortRelevanceWithKeywordPresence(sortOptions []queryparams.SortOption, searchTerm string) []queryparams.SortOption {
-	var options []queryparams.SortOption
-
-	for _, option := range sortOptions {
-		if option.Value == "relevance" {
-			if searchTerm == "" {
-				option.Disabled = true
-			} else {
-				option.Disabled = false
-			}
-		}
-
-		options = append(options, option)
-	}
-
-	return options
-}
-
 func CreateReleaseCalendar(basePage coreModel.Page, params queryparams.ValidatedParams, response search.ReleaseResponse, cfg config.Config) model.Calendar {
 	calendar := model.Calendar{
 		Page: basePage,
@@ -299,7 +281,7 @@ func CreateReleaseCalendar(basePage coreModel.Page, params queryparams.Validated
 
 	calendar.Sort = model.Sort{
 		Mode:    params.Sort.String(),
-		Options: associateSortRelevanceWithKeywordPresence(queryparams.SortOptions, calendar.KeywordSearch.SearchTerm),
+		Options: mapSortOptions(params),
 	}
 
 	calendar.AfterDate = coreModel.InputDate{
@@ -772,6 +754,46 @@ func mapReleases(params queryparams.ValidatedParams, response search.ReleaseResp
 			Language:  language,
 			Checked:   checkType(params.ReleaseType, queryparams.Cancelled),
 			Count:     response.Breakdown.Cancelled,
+		},
+	}
+}
+
+func mapSortOptions(params queryparams.ValidatedParams) []model.SortOption {
+	return []model.SortOption{
+		{
+			LocaleKey: "ReleaseCalendarSortOptionDateNewest",
+			Plural:    1,
+			Value:     queryparams.RelDateDesc.String(),
+			Disabled:  false,
+		},
+		{
+			LocaleKey: "ReleaseCalendarSortOptionDateOldest",
+			Plural:    1,
+			Value:     queryparams.RelDateAsc.String(),
+			Disabled:  false,
+		},
+		{
+			LocaleKey: "ReleaseCalendarSortOptionAlphabeticalAZ",
+			Plural:    1,
+			Value:     queryparams.TitleAZ.String(),
+			Disabled:  false,
+		},
+		{
+			LocaleKey: "ReleaseCalendarSortOptionAlphabeticalZA",
+			Plural:    1,
+			Value:     queryparams.TitleZA.String(),
+			Disabled:  false,
+		},
+		{
+			LocaleKey: "ReleaseCalendarSortOptionRelevance",
+			Plural:    1,
+			Value:     queryparams.Relevance.String(),
+			Disabled: func(keywords string) bool {
+				if keywords == "" {
+					return true
+				}
+				return false
+			}(params.Keywords),
 		},
 	}
 }

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -243,7 +243,7 @@ func TestReleaseCalendarMapper(t *testing.T) {
 			So(calendar.BetaBannerEnabled, ShouldBeTrue)
 			So(calendar.Metadata.Title, ShouldEqual, "Release Calendar")
 			So(calendar.KeywordSearch.SearchTerm, ShouldEqual, params.Keywords)
-			So(calendar.Sort, ShouldResemble, model.Sort{Mode: params.Sort.String(), Options: queryparams.SortOptions})
+			So(calendar.Sort, ShouldResemble, model.Sort{Mode: params.Sort.String(), Options: mapSortOptions(params)})
 			So(calendar.BeforeDate, ShouldResemble, coreModel.InputDate{
 				Language:        basePage.Language,
 				Id:              "before-date",

--- a/model/calendar.go
+++ b/model/calendar.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"github.com/ONSdigital/dp-frontend-release-calendar/queryparams"
 	coreModel "github.com/ONSdigital/dp-renderer/model"
 )
 
@@ -24,7 +23,12 @@ type ReleaseType struct {
 	SubTypes  map[string]ReleaseType `json:"sub_types"`
 }
 
-type SortOption = queryparams.SortOption
+type SortOption struct {
+	LocaleKey string `json:"locale_key"`
+	Plural    int    `json:"plural"`
+	Value     string `json:"value"`
+	Disabled  bool   `json:"disabled"`
+}
 
 type Sort struct {
 	Mode    string       `json:"mode"`

--- a/queryparams/params.go
+++ b/queryparams/params.go
@@ -316,6 +316,7 @@ type SortOption struct {
 	LocaleKey string `json:"locale_key"`
 	Plural    int    `json:"plural"`
 	Value     string `json:"value"`
+	Disabled  bool   `json:"disabled"`
 }
 
 var SortOptions = []SortOption{
@@ -323,26 +324,31 @@ var SortOptions = []SortOption{
 		LocaleKey: "ReleaseCalendarSortOptionDateNewest",
 		Plural:    1,
 		Value:     sortNames[RelDateDesc],
+		Disabled:  false,
 	},
 	{
 		LocaleKey: "ReleaseCalendarSortOptionDateOldest",
 		Plural:    1,
 		Value:     sortNames[RelDateAsc],
+		Disabled:  false,
 	},
 	{
 		LocaleKey: "ReleaseCalendarSortOptionAlphabeticalAZ",
 		Plural:    1,
 		Value:     sortNames[TitleAZ],
+		Disabled:  false,
 	},
 	{
 		LocaleKey: "ReleaseCalendarSortOptionAlphabeticalZA",
 		Plural:    1,
 		Value:     sortNames[TitleZA],
+		Disabled:  false,
 	},
 	{
 		LocaleKey: "ReleaseCalendarSortOptionRelevance",
 		Plural:    1,
 		Value:     sortNames[Relevance],
+		Disabled:  false,
 	},
 }
 

--- a/queryparams/params.go
+++ b/queryparams/params.go
@@ -117,6 +117,11 @@ func GetSortOrder(ctx context.Context, params url.Values, defaultValue Sort) (So
 		}
 	}
 
+	// When keywords are empty in this case, force the sort order back to the default.
+	if params.Get(Keywords) == "" && sort == Relevance {
+		return defaultValue, nil
+	}
+
 	return sort, nil
 }
 

--- a/queryparams/params.go
+++ b/queryparams/params.go
@@ -282,11 +282,11 @@ const (
 	Relevance
 )
 
-var sortNames = map[Sort]string{RelDateAsc: "date-oldest", RelDateDesc: "date-newest", TitleAZ: "alphabetical-az", TitleZA: "alphabetical-za", Relevance: "relevance", Invalid: "invalid"}
-var sortOptions = map[Sort]string{RelDateAsc: "release_date_asc", RelDateDesc: "release_date_desc", TitleAZ: "title_asc", TitleZA: "title_desc", Relevance: "relevance", Invalid: "invalid"}
+var feSortNames = map[Sort]string{RelDateAsc: "date-oldest", RelDateDesc: "date-newest", TitleAZ: "alphabetical-az", TitleZA: "alphabetical-za", Relevance: "relevance", Invalid: "invalid"}
+var beSortNames = map[Sort]string{RelDateAsc: "release_date_asc", RelDateDesc: "release_date_desc", TitleAZ: "title_asc", TitleZA: "title_desc", Relevance: "relevance", Invalid: "invalid"}
 
 func ParseSort(sort string) (Sort, error) {
-	for s, sn := range sortNames {
+	for s, sn := range feSortNames {
 		if strings.EqualFold(sort, sn) {
 			return s, nil
 		}
@@ -305,51 +305,11 @@ func MustParseSort(sort string) Sort {
 }
 
 func (s Sort) String() string {
-	return sortNames[s]
+	return feSortNames[s]
 }
 
-func (s Sort) OptionString() string {
-	return sortOptions[s]
-}
-
-type SortOption struct {
-	LocaleKey string `json:"locale_key"`
-	Plural    int    `json:"plural"`
-	Value     string `json:"value"`
-	Disabled  bool   `json:"disabled"`
-}
-
-var SortOptions = []SortOption{
-	{
-		LocaleKey: "ReleaseCalendarSortOptionDateNewest",
-		Plural:    1,
-		Value:     sortNames[RelDateDesc],
-		Disabled:  false,
-	},
-	{
-		LocaleKey: "ReleaseCalendarSortOptionDateOldest",
-		Plural:    1,
-		Value:     sortNames[RelDateAsc],
-		Disabled:  false,
-	},
-	{
-		LocaleKey: "ReleaseCalendarSortOptionAlphabeticalAZ",
-		Plural:    1,
-		Value:     sortNames[TitleAZ],
-		Disabled:  false,
-	},
-	{
-		LocaleKey: "ReleaseCalendarSortOptionAlphabeticalZA",
-		Plural:    1,
-		Value:     sortNames[TitleZA],
-		Disabled:  false,
-	},
-	{
-		LocaleKey: "ReleaseCalendarSortOptionRelevance",
-		Plural:    1,
-		Value:     sortNames[Relevance],
-		Disabled:  false,
-	},
+func (s Sort) BackendString() string {
+	return beSortNames[s]
 }
 
 type Date struct {

--- a/queryparams/params_test.go
+++ b/queryparams/params_test.go
@@ -165,7 +165,6 @@ func TestSort(t *testing.T) {
 				{given: "date-newest", exValue: RelDateDesc},
 				{given: "alphabetical-az", exValue: TitleAZ},
 				{given: "alphabetical-za", exValue: TitleZA},
-				{given: "relevance", exValue: Relevance},
 			}
 
 			for _, gso := range goodSortOptions {
@@ -179,6 +178,22 @@ func TestSort(t *testing.T) {
 				So(e, ShouldBeNil)
 
 			}
+		})
+		Convey("except for the 'relevance' sort option - this parses as normal", func() {
+			v, e := ParseSort("relevance")
+
+			So(v, ShouldEqual, Relevance)
+			So(e, ShouldBeNil)
+
+			Convey("but can only be set if a keyword has also been set", func() {
+				v, e = GetSortOrder(context.Background(), url.Values{SortName: []string{"relevance"}, Keywords: []string{"keywords set"}}, RelDateDesc)
+				So(v, ShouldEqual, Relevance)
+				So(e, ShouldBeNil)
+
+				v, e = GetSortOrder(context.Background(), url.Values{SortName: []string{"relevance"}}, RelDateDesc)
+				So(v, ShouldEqual, RelDateDesc)
+				So(e, ShouldBeNil)
+			})
 		})
 	})
 }


### PR DESCRIPTION
### What

The presence or absence of a search term (i.e. keywords) governs the availability of the 'Relevance' sort option.

Additionally, each time new keywords are submitted the sort order is forced over to 'Relevance' as the most sensible default when keywords are present - this sort order can be overridden with the 'Sort by' control.

When keywords are cleared and submitted, the sort order is forced over to the default (Newest) as the most sensible default in the absence of keywords - this can be overridden with the 'Sort by' control.
- The address bar in the browser will continue to say `sort=relevance` when the server forces the sort order back to Newest. This is normal as the server cannot update the address bar, and has no ill effect as the page body retains the correct state for all future interactions with the server.

![Screenshot 2022-04-22 at 16 52 32](https://user-images.githubusercontent.com/912770/164750625-fcf9ac80-a961-4fcc-922d-ee2fe12ebad0.png)

![Screenshot 2022-04-22 at 16 52 46](https://user-images.githubusercontent.com/912770/164750635-f1e27130-b8c5-46df-8e02-3aa998566990.png)

### How to review

In addition to code inspection, it helps to get a feel for this change by driving the UI through different states with and without keywords present.

### Who can review

Frontend design system / Go developers
