### PR TITLE
Collapse Search and Date filters unless they are populated

### DIFF
--- a/assets/templates/partials/calendar/filters.tmpl
+++ b/assets/templates/partials/calendar/filters.tmpl
@@ -29,7 +29,11 @@
       class="ons-collapsible ons-js-collapsible ons-collapsible--accordion"
       data-btn-close="Hide"
       data-group="accordion"
-      data-open="true"
+      {{ if .IsFilterSearchPresent }}
+        data-open="true"
+      {{ else }}
+        data-open="false"
+      {{ end }}
     >
       <div class="ons-collapsible__heading ons-js-collapsible-heading">
         <div class="ons-collapsible__controls">
@@ -48,7 +52,11 @@
       class="ons-collapsible ons-js-collapsible ons-collapsible--accordion"
       data-btn-close="Hide"
       data-group="accordion"
-      data-open="true"
+      {{ if .IsFilterDatePresent }}
+        data-open="true"
+      {{ else }}
+        data-open="false"
+      {{ end }}
     >
       <div class="ons-collapsible__heading ons-js-collapsible-heading">
         <div class="ons-collapsible__controls">

--- a/assets/templates/partials/calendar/filters.tmpl
+++ b/assets/templates/partials/calendar/filters.tmpl
@@ -29,7 +29,7 @@
       class="ons-collapsible ons-js-collapsible ons-collapsible--accordion"
       data-btn-close="Hide"
       data-group="accordion"
-      {{ if .IsFilterSearchPresent }}
+      {{ if .FuncIsFilterSearchPresent }}
         data-open="true"
       {{ else }}
         data-open="false"
@@ -52,7 +52,7 @@
       class="ons-collapsible ons-js-collapsible ons-collapsible--accordion"
       data-btn-close="Hide"
       data-group="accordion"
-      {{ if .IsFilterDatePresent }}
+      {{ if .FuncIsFilterDatePresent }}
         data-open="true"
       {{ else }}
         data-open="false"

--- a/model/calendar.go
+++ b/model/calendar.go
@@ -46,3 +46,23 @@ type Calendar struct {
 	Entries       []CalendarEntry         `json:"entries"`
 	KeywordSearch coreModel.CompactSearch `json:"keyword_search"`
 }
+
+func (calendar Calendar) IsFilterSearchPresent() bool {
+	return calendar.KeywordSearch.SearchTerm != ""
+}
+
+func (calendar Calendar) IsFilterDatePresent() bool {
+	isBeforeDatePresent := func() bool {
+		return calendar.BeforeDate.InputValueDay != "" &&
+			calendar.BeforeDate.InputValueMonth != "" &&
+			calendar.BeforeDate.InputValueYear != ""
+	}
+
+	isAfterDatePresent := func() bool {
+		return calendar.AfterDate.InputValueDay != "" &&
+			calendar.AfterDate.InputValueMonth != "" &&
+			calendar.AfterDate.InputValueYear != ""
+	}
+
+	return isBeforeDatePresent() || isAfterDatePresent()
+}

--- a/model/calendar.go
+++ b/model/calendar.go
@@ -47,11 +47,11 @@ type Calendar struct {
 	KeywordSearch coreModel.CompactSearch `json:"keyword_search"`
 }
 
-func (calendar Calendar) IsFilterSearchPresent() bool {
+func (calendar Calendar) FuncIsFilterSearchPresent() bool {
 	return calendar.KeywordSearch.SearchTerm != ""
 }
 
-func (calendar Calendar) IsFilterDatePresent() bool {
+func (calendar Calendar) FuncIsFilterDatePresent() bool {
 	isBeforeDatePresent := func() bool {
 		return calendar.BeforeDate.InputValueDay != "" &&
 			calendar.BeforeDate.InputValueMonth != "" &&

--- a/model/calendar_test.go
+++ b/model/calendar_test.go
@@ -1,0 +1,79 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/ONSdigital/dp-frontend-release-calendar/model"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestUnitMapper(t *testing.T) {
+	Convey("IsFilterSearchPresent should detect the presence or absence of a search term", t, func() {
+		Convey("When a search term is absent", func() {
+			calendar := model.Calendar{}
+			So(calendar.IsFilterSearchPresent(), ShouldEqual, false)
+		})
+
+		Convey("When a search term is present", func() {
+			calendar := model.Calendar{}
+			calendar.KeywordSearch.SearchTerm = "populated"
+			So(calendar.IsFilterSearchPresent(), ShouldEqual, true)
+		})
+	})
+
+	Convey("IsFilterDatePresent should detect the presence or absence of a date", t, func() {
+		Convey("When both dates are absent", func() {
+			calendar := model.Calendar{}
+			So(calendar.IsFilterDatePresent(), ShouldEqual, false)
+		})
+
+		Convey("When an AfterDate is present", func() {
+			calendar := model.Calendar{}
+			calendar.AfterDate.InputValueDay = "01"
+			calendar.AfterDate.InputValueMonth = "01"
+			calendar.AfterDate.InputValueYear = "2000"
+			So(calendar.IsFilterDatePresent(), ShouldEqual, true)
+
+			calendar.AfterDate.InputValueMonth = ""
+			So(calendar.IsFilterDatePresent(), ShouldEqual, false)
+
+			calendar.AfterDate.InputValueMonth = "01"
+			calendar.AfterDate.InputValueDay = ""
+			So(calendar.IsFilterDatePresent(), ShouldEqual, false)
+
+			calendar.AfterDate.InputValueDay = "01"
+			calendar.AfterDate.InputValueYear = ""
+			So(calendar.IsFilterDatePresent(), ShouldEqual, false)
+		})
+
+		Convey("When a BeforeDate is present", func() {
+			calendar := model.Calendar{}
+			calendar.BeforeDate.InputValueDay = "01"
+			calendar.BeforeDate.InputValueMonth = "01"
+			calendar.BeforeDate.InputValueYear = "2000"
+			So(calendar.IsFilterDatePresent(), ShouldEqual, true)
+
+			calendar.BeforeDate.InputValueMonth = ""
+			So(calendar.IsFilterDatePresent(), ShouldEqual, false)
+
+			calendar.BeforeDate.InputValueMonth = "01"
+			calendar.BeforeDate.InputValueDay = ""
+			So(calendar.IsFilterDatePresent(), ShouldEqual, false)
+
+			calendar.BeforeDate.InputValueDay = "01"
+			calendar.BeforeDate.InputValueYear = ""
+			So(calendar.IsFilterDatePresent(), ShouldEqual, false)
+		})
+
+		Convey("When both dates are present", func() {
+			calendar := model.Calendar{}
+			calendar.AfterDate.InputValueDay = "01"
+			calendar.AfterDate.InputValueMonth = "01"
+			calendar.AfterDate.InputValueYear = "2000"
+			calendar.BeforeDate.InputValueDay = "01"
+			calendar.BeforeDate.InputValueMonth = "01"
+			calendar.BeforeDate.InputValueYear = "2000"
+			So(calendar.IsFilterDatePresent(), ShouldEqual, true)
+		})
+	})
+}

--- a/model/calendar_test.go
+++ b/model/calendar_test.go
@@ -8,23 +8,23 @@ import (
 )
 
 func TestUnitMapper(t *testing.T) {
-	Convey("IsFilterSearchPresent should detect the presence or absence of a search term", t, func() {
+	Convey("FuncIsFilterSearchPresent should detect the presence or absence of a search term", t, func() {
 		Convey("When a search term is absent", func() {
 			calendar := model.Calendar{}
-			So(calendar.IsFilterSearchPresent(), ShouldBeFalse)
+			So(calendar.FuncIsFilterSearchPresent(), ShouldBeFalse)
 		})
 
 		Convey("When a search term is present", func() {
 			calendar := model.Calendar{}
 			calendar.KeywordSearch.SearchTerm = "populated"
-			So(calendar.IsFilterSearchPresent(), ShouldBeTrue)
+			So(calendar.FuncIsFilterSearchPresent(), ShouldBeTrue)
 		})
 	})
 
-	Convey("IsFilterDatePresent should detect the presence or absence of a date", t, func() {
+	Convey("FuncIsFilterDatePresent should detect the presence or absence of a date", t, func() {
 		Convey("When both dates are absent", func() {
 			calendar := model.Calendar{}
-			So(calendar.IsFilterDatePresent(), ShouldBeFalse)
+			So(calendar.FuncIsFilterDatePresent(), ShouldBeFalse)
 		})
 
 		Convey("When an AfterDate is present", func() {
@@ -32,18 +32,18 @@ func TestUnitMapper(t *testing.T) {
 			calendar.AfterDate.InputValueDay = "01"
 			calendar.AfterDate.InputValueMonth = "01"
 			calendar.AfterDate.InputValueYear = "2000"
-			So(calendar.IsFilterDatePresent(), ShouldBeTrue)
+			So(calendar.FuncIsFilterDatePresent(), ShouldBeTrue)
 
 			calendar.AfterDate.InputValueMonth = ""
-			So(calendar.IsFilterDatePresent(), ShouldBeFalse)
+			So(calendar.FuncIsFilterDatePresent(), ShouldBeFalse)
 
 			calendar.AfterDate.InputValueMonth = "01"
 			calendar.AfterDate.InputValueDay = ""
-			So(calendar.IsFilterDatePresent(), ShouldBeFalse)
+			So(calendar.FuncIsFilterDatePresent(), ShouldBeFalse)
 
 			calendar.AfterDate.InputValueDay = "01"
 			calendar.AfterDate.InputValueYear = ""
-			So(calendar.IsFilterDatePresent(), ShouldBeFalse)
+			So(calendar.FuncIsFilterDatePresent(), ShouldBeFalse)
 		})
 
 		Convey("When a BeforeDate is present", func() {
@@ -51,18 +51,18 @@ func TestUnitMapper(t *testing.T) {
 			calendar.BeforeDate.InputValueDay = "01"
 			calendar.BeforeDate.InputValueMonth = "01"
 			calendar.BeforeDate.InputValueYear = "2000"
-			So(calendar.IsFilterDatePresent(), ShouldBeTrue)
+			So(calendar.FuncIsFilterDatePresent(), ShouldBeTrue)
 
 			calendar.BeforeDate.InputValueMonth = ""
-			So(calendar.IsFilterDatePresent(), ShouldBeFalse)
+			So(calendar.FuncIsFilterDatePresent(), ShouldBeFalse)
 
 			calendar.BeforeDate.InputValueMonth = "01"
 			calendar.BeforeDate.InputValueDay = ""
-			So(calendar.IsFilterDatePresent(), ShouldBeFalse)
+			So(calendar.FuncIsFilterDatePresent(), ShouldBeFalse)
 
 			calendar.BeforeDate.InputValueDay = "01"
 			calendar.BeforeDate.InputValueYear = ""
-			So(calendar.IsFilterDatePresent(), ShouldBeFalse)
+			So(calendar.FuncIsFilterDatePresent(), ShouldBeFalse)
 		})
 
 		Convey("When both dates are present", func() {
@@ -73,7 +73,7 @@ func TestUnitMapper(t *testing.T) {
 			calendar.BeforeDate.InputValueDay = "01"
 			calendar.BeforeDate.InputValueMonth = "01"
 			calendar.BeforeDate.InputValueYear = "2000"
-			So(calendar.IsFilterDatePresent(), ShouldBeTrue)
+			So(calendar.FuncIsFilterDatePresent(), ShouldBeTrue)
 		})
 	})
 }

--- a/model/calendar_test.go
+++ b/model/calendar_test.go
@@ -11,20 +11,20 @@ func TestUnitMapper(t *testing.T) {
 	Convey("IsFilterSearchPresent should detect the presence or absence of a search term", t, func() {
 		Convey("When a search term is absent", func() {
 			calendar := model.Calendar{}
-			So(calendar.IsFilterSearchPresent(), ShouldEqual, false)
+			So(calendar.IsFilterSearchPresent(), ShouldBeFalse)
 		})
 
 		Convey("When a search term is present", func() {
 			calendar := model.Calendar{}
 			calendar.KeywordSearch.SearchTerm = "populated"
-			So(calendar.IsFilterSearchPresent(), ShouldEqual, true)
+			So(calendar.IsFilterSearchPresent(), ShouldBeTrue)
 		})
 	})
 
 	Convey("IsFilterDatePresent should detect the presence or absence of a date", t, func() {
 		Convey("When both dates are absent", func() {
 			calendar := model.Calendar{}
-			So(calendar.IsFilterDatePresent(), ShouldEqual, false)
+			So(calendar.IsFilterDatePresent(), ShouldBeFalse)
 		})
 
 		Convey("When an AfterDate is present", func() {
@@ -32,18 +32,18 @@ func TestUnitMapper(t *testing.T) {
 			calendar.AfterDate.InputValueDay = "01"
 			calendar.AfterDate.InputValueMonth = "01"
 			calendar.AfterDate.InputValueYear = "2000"
-			So(calendar.IsFilterDatePresent(), ShouldEqual, true)
+			So(calendar.IsFilterDatePresent(), ShouldBeTrue)
 
 			calendar.AfterDate.InputValueMonth = ""
-			So(calendar.IsFilterDatePresent(), ShouldEqual, false)
+			So(calendar.IsFilterDatePresent(), ShouldBeFalse)
 
 			calendar.AfterDate.InputValueMonth = "01"
 			calendar.AfterDate.InputValueDay = ""
-			So(calendar.IsFilterDatePresent(), ShouldEqual, false)
+			So(calendar.IsFilterDatePresent(), ShouldBeFalse)
 
 			calendar.AfterDate.InputValueDay = "01"
 			calendar.AfterDate.InputValueYear = ""
-			So(calendar.IsFilterDatePresent(), ShouldEqual, false)
+			So(calendar.IsFilterDatePresent(), ShouldBeFalse)
 		})
 
 		Convey("When a BeforeDate is present", func() {
@@ -51,18 +51,18 @@ func TestUnitMapper(t *testing.T) {
 			calendar.BeforeDate.InputValueDay = "01"
 			calendar.BeforeDate.InputValueMonth = "01"
 			calendar.BeforeDate.InputValueYear = "2000"
-			So(calendar.IsFilterDatePresent(), ShouldEqual, true)
+			So(calendar.IsFilterDatePresent(), ShouldBeTrue)
 
 			calendar.BeforeDate.InputValueMonth = ""
-			So(calendar.IsFilterDatePresent(), ShouldEqual, false)
+			So(calendar.IsFilterDatePresent(), ShouldBeFalse)
 
 			calendar.BeforeDate.InputValueMonth = "01"
 			calendar.BeforeDate.InputValueDay = ""
-			So(calendar.IsFilterDatePresent(), ShouldEqual, false)
+			So(calendar.IsFilterDatePresent(), ShouldBeFalse)
 
 			calendar.BeforeDate.InputValueDay = "01"
 			calendar.BeforeDate.InputValueYear = ""
-			So(calendar.IsFilterDatePresent(), ShouldEqual, false)
+			So(calendar.IsFilterDatePresent(), ShouldBeFalse)
 		})
 
 		Convey("When both dates are present", func() {
@@ -73,7 +73,7 @@ func TestUnitMapper(t *testing.T) {
 			calendar.BeforeDate.InputValueDay = "01"
 			calendar.BeforeDate.InputValueMonth = "01"
 			calendar.BeforeDate.InputValueYear = "2000"
-			So(calendar.IsFilterDatePresent(), ShouldEqual, true)
+			So(calendar.IsFilterDatePresent(), ShouldBeTrue)
 		})
 	})
 }


### PR DESCRIPTION
### What

By default, the Search and Date filters will be collapsed to make the filters more compact, especially on mobile where the user must scroll past them to reach the search results.

<img width="355" alt="Screenshot 2022-04-26 at 12 38 27" src="https://user-images.githubusercontent.com/912770/165292135-0900362c-1761-4ebf-8b58-fb590d46fcfd.png">

When either field is populated and playing an active role, it will be expanded when the server re-renders the page:

- with a search term

<img width="363" alt="Screenshot 2022-04-26 at 12 40 34" src="https://user-images.githubusercontent.com/912770/165292510-7e06f56a-ea53-47a0-95ee-769b546604a0.png">

- with a date

<img width="376" alt="Screenshot 2022-04-26 at 12 41 00" src="https://user-images.githubusercontent.com/912770/165292559-050c7ce2-aeb8-44b2-b163-5dbe323c1c6e.png">


### How to review

- In a separate shell run the dp-design-system with `make debug`
- Run this frontend controller with `make debug`
- Add and remove search term and dates to verify behaviour of accordion sections

### Who can review

Frontend / Design System developers

