### PR TITLE
Increase spacing between results and pagination control

### DIFF
--- a/assets/templates/partials/calendar/items/list.tmpl
+++ b/assets/templates/partials/calendar/items/list.tmpl
@@ -4,7 +4,7 @@
   tag designed for the purpose:
     <em class="ons-highlight">keyword</em>
 */}}
-<ol class="ons-list ons-list--bare ons-u-bt">
+<ol class="ons-list ons-list--bare ons-u-bt ons-u-mb-l">
   {{range .Entries }}
     <li class="ons-list__item ons-u-mt-l">
       <a


### PR DESCRIPTION
### What

The pagination control is further down the page from the results so that it appears to stand apart rather than be associated, visually, with the last result in the list. The separation is the same as the space between results.

- Desktop

<img width="755" alt="Screenshot 2022-04-26 at 15 30 49" src="https://user-images.githubusercontent.com/912770/165323756-e31cc98f-5279-4688-afcd-a272fef8aacb.png">

- Mobile

<img width="373" alt="Screenshot 2022-04-26 at 15 30 37" src="https://user-images.githubusercontent.com/912770/165323812-c78971b9-6120-416a-988c-b0fc9b469992.png">

### How to review

- In a separate shell run dp-design-system with `make debug`
- Run this frontend controller with `make debug`
- Verify the separation between the last result and pagination in each device mode.

### Who can review

Anyone
