### PR TITLE
Release type filter radios auto-submit on change

### DIFF
--- a/assets/templates/partials/calendar/filter/release-type.tmpl
+++ b/assets/templates/partials/calendar/filter/release-type.tmpl
@@ -1,4 +1,4 @@
-<form>
+<form class="filters__release-type">
     {{/* Include all other page settings in the form submission */}}
     {{ template "partials/calendar/hidden-inputs/keywords" . }}
     {{ template "partials/calendar/hidden-inputs/sort-mode" . }}
@@ -37,7 +37,7 @@
     </fieldset>
     <button
       type="submit"
-      class="ons-btn ons-btn--secondary ons-u-mt-s text-wrap"
+      class="ons-btn ons-btn--secondary ons-u-mt-s text-wrap js--hide"
     >
         <span class="ons-btn__inner">
           {{- localise "FilterReleaseTypeApplyFilters" .Language 1 -}}

--- a/config/config.go
+++ b/config/config.go
@@ -39,7 +39,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/7aa530a"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/5f45c7f"
 	}
 
 	return cfg, nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,7 +22,7 @@ func TestConfig(t *testing.T) {
 			Convey("Then the values should be set to the expected defaults", func() {
 				So(cfg.Debug, ShouldBeFalse)
 				So(cfg.BindAddr, ShouldEqual, ":27700")
-				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/7aa530a")
+				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/5f45c7f")
 				So(cfg.SupportedLanguages, ShouldResemble, []string{"en", "cy"})
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)


### PR DESCRIPTION
### What

Release Type filter radio buttons on the Release Calendar auto-submit the form when selecting a different radio button.

- JavaScript enabled

<img width="346" alt="Screenshot 2022-04-27 at 16 13 39" src="https://user-images.githubusercontent.com/912770/165563310-3f21854a-f94d-45a6-9139-abe2ea4f6c7f.png">

- JavaScript disabled

<img width="347" alt="Screenshot 2022-04-27 at 16 13 50" src="https://user-images.githubusercontent.com/912770/165563345-9b628370-ff38-4ea7-b6d6-c599f535bd2f.png">

### How to review

- In a separate shell run the dp-design-system with `make debug`
- Run the frontend controller with `make debug`
- Verify that, with JavaScript enabled, radio buttons immediately update the search results when selected 
- Verify that, with JavaScript disabled, radio button changes are honoured when clicking 'Apply release type filters'

### Who can review

Frontend / Design System developers
