### PR TITLE
Use ONS Date Pattern in Release Calendar search results timestamps

### DIFF
--- a/assets/templates/partials/calendar/items/list.tmpl
+++ b/assets/templates/partials/calendar/items/list.tmpl
@@ -15,7 +15,7 @@
       </a>
       <div class="ons-u-mt-s">
         <span class="ons-u-fs-r--b">Release date:</span>
-        <span>{{ dateTimeFormat .Description.ReleaseDate }}</span>
+        <span>{{ dateTimeOnsDatePatternFormat .Description.ReleaseDate }}</span>
         <span>|</span>
         <span>
           {{ if .Description.Published }}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.104.0
 	github.com/ONSdigital/dp-healthcheck v1.2.3
 	github.com/ONSdigital/dp-net/v2 v2.0.0
-	github.com/ONSdigital/dp-renderer v1.25.4
+	github.com/ONSdigital/dp-renderer v1.26.0
 	github.com/ONSdigital/log.go/v2 v2.1.0
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/ONSdigital/dp-renderer v1.24.2 h1:/+In6j3pXLRp8H8SI96UwWX76Is7MA6rfhl
 github.com/ONSdigital/dp-renderer v1.24.2/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/dp-renderer v1.25.4 h1:2vuM9wYaYMHSDPtfv+SrKSlgsp2HlNUB4Txyg+xn5yQ=
 github.com/ONSdigital/dp-renderer v1.25.4/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
+github.com/ONSdigital/dp-renderer v1.26.0 h1:jVB0adtXsoCaTir8+mlm61UvG1j5nJAHjxBk2vGfH6I=
+github.com/ONSdigital/dp-renderer v1.26.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=


### PR DESCRIPTION
### What

Imports dp-renderer v1.26.0 so that timestamps in Release Calendar search results are formatted according to the new ONS Date Pattern i.e. 9 November 2010 4:15am

<img width="776" alt="Screenshot 2022-04-28 at 17 26 15" src="https://user-images.githubusercontent.com/912770/165923192-021d2242-36c2-455b-8f8f-940a75f6bc93.png">

### How to review

- Run the dp-design-system in a separate shell with `make debug`
- Run the frontend controller with `make debug`
- Verify that the Release Calendar search results use timestamps in the new format

### Who can review

Frontend / design system developers
