### PR TITLE
Breadcrumb trail localised with correct links

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -111,3 +111,23 @@ one = "Ar ddod"
 [FilterReleaseTypeCancelled]
 description = "Cancelled"
 one = "Canslwyd"
+
+[BreadcrumbHome]
+description = "Home"
+one = "Hafan"
+
+[BreadcrumbReleaseCalendar]
+description = "Release calendar"
+one = "Calendr datganiadau"
+
+[BreadcrumbPublished]
+description = "Published"
+one = "Cyhoeddwyd"
+
+[BreadcrumbUpcoming]
+description = "Upcoming"
+one = "Ar ddod"
+
+[BreadcrumbCancelled]
+description = "Cancelled"
+one = "Canslwyd"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -111,3 +111,23 @@ one = "Upcoming"
 [FilterReleaseTypeCancelled]
 description = "Cancelled"
 one = "Cancelled"
+
+[BreadcrumbHome]
+description = "Home"
+one = "Home"
+
+[BreadcrumbReleaseCalendar]
+description = "Release calendar"
+one = "Release calendar"
+
+[BreadcrumbPublished]
+description = "Published"
+one = "Published"
+
+[BreadcrumbUpcoming]
+description = "Upcoming"
+one = "Upcoming"
+
+[BreadcrumbCancelled]
+description = "Cancelled"
+one = "Cancelled"

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -2,6 +2,7 @@ package mapper
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -223,7 +224,6 @@ func CreateRelease(basePage coreModel.Page, release releasecalendar.Release) mod
 			ProvisionalDate:    release.Description.ProvisionalDate,
 		},
 	}
-
 	result.RelatedDatasets = mapLink(release.RelatedDatasets)
 	result.RelatedDocuments = mapLink(release.RelatedDocuments)
 	result.RelatedMethodology = mapLink(release.RelatedMethodology)
@@ -242,24 +242,7 @@ func CreateRelease(basePage coreModel.Page, release releasecalendar.Release) mod
 	result.Metadata.Title = release.Description.Title
 	result.URI = release.URI
 	result.CodeOfPractice = true
-
-	result.Breadcrumb = []coreModel.TaxonomyNode{
-		{
-			Title: "Home",
-			URI:   "/",
-		},
-		{
-			Title: "Release calendar",
-			URI:   "/calendar",
-		},
-		{
-			Title: "Published", // TODO Set this from data
-			URI:   "/calendar", // TODO Integrate with Search API
-		},
-		{
-			Title: release.Description.Title,
-		},
-	}
+	result.Breadcrumb = mapBreadcrumbTrail(result.Description, result.Language)
 
 	result.TableOfContents = createTableOfContents(
 		result.Description,
@@ -271,6 +254,40 @@ func CreateRelease(basePage coreModel.Page, release releasecalendar.Release) mod
 	)
 
 	return result
+}
+
+func mapBreadcrumbTrail(description model.ReleaseDescription, language string) []coreModel.TaxonomyNode {
+	selectState := func(description model.ReleaseDescription) (string, queryparams.ReleaseType) {
+		if description.Cancelled {
+			return "BreadcrumbCancelled", queryparams.Cancelled
+		}
+
+		if description.Published {
+			return "BreadcrumbPublished", queryparams.Published
+		}
+
+		return "BreadcrumbUpcoming", queryparams.Upcoming
+	}
+
+	localeKey, releaseType := selectState(description)
+
+	return []coreModel.TaxonomyNode{
+		{
+			Title: helper.Localise("BreadcrumbHome", language, 1),
+			URI:   "/",
+		},
+		{
+			Title: helper.Localise("BreadcrumbReleaseCalendar", language, 1),
+			URI:   "/releasecalendar",
+		},
+		{
+			Title: helper.Localise(localeKey, language, 1),
+			URI:   fmt.Sprintf("/releasecalendar?release-type=%s", releaseType.String()),
+		},
+		{
+			Title: description.Title,
+		},
+	}
 }
 
 func mapLink(links []releasecalendar.Link) []model.Link {

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -140,6 +140,22 @@ func TestUnitMapper(t *testing.T) {
 			So(model.Description.Cancelled, ShouldEqual, release.Description.Cancelled)
 			So(model.Description.CancellationNotice, ShouldResemble, release.Description.CancellationNotice)
 			So(model.Description.ProvisionalDate, ShouldEqual, release.Description.ProvisionalDate)
+			So(model.Breadcrumb, ShouldResemble, []coreModel.TaxonomyNode{
+				{
+					Title: "Home",
+					URI:   "/",
+				},
+				{
+					Title: "Release calendar",
+					URI:   "/releasecalendar",
+				},
+				{
+					Title: "Cancelled",
+					URI:   "/releasecalendar?release-type=type-cancelled",
+				}, {
+					Title: "Release title",
+				},
+			})
 		})
 	})
 }

--- a/mocks/mock_assets.go
+++ b/mocks/mock_assets.go
@@ -15,6 +15,8 @@ var cyLocale = []string{
 	"one=\"Hafan\"",
 	"[BreadcrumbReleaseCalendar]",
 	"one = \"Calendr datganiadau\"",
+	"[BreadcrumbUpcoming]",
+	"one = \"Ar ddod\"",
 	"[BreadcrumbCancelled]",
 	"one = \"Canslwyd\"",
 }
@@ -32,6 +34,8 @@ var enLocale = []string{
 	"one=\"Home\"",
 	"[BreadcrumbReleaseCalendar]",
 	"one = \"Release calendar\"",
+	"[BreadcrumbUpcoming]",
+	"one = \"Upcoming\"",
 	"[BreadcrumbCancelled]",
 	"one = \"Cancelled\"",
 }

--- a/mocks/mock_assets.go
+++ b/mocks/mock_assets.go
@@ -2,9 +2,43 @@ package mocks
 
 import "strings"
 
+var cyLocale = []string{
+	"[ReleasedAfter]",
+	"one = \"Cyhoeddwyd ar ôl\"",
+	"[ReleasedBefore]",
+	"one = \"Cyhoeddwyd cyn\"",
+	"[DateFilterDescription]",
+	"one=\"Er enghraifft: 2006 neu 19/07/2010\"",
+	"[ReleaseCalendarPageTitle]",
+	"one=\"Calendr datganiadau\"",
+	"[BreadcrumbHome]",
+	"one=\"Hafan\"",
+	"[BreadcrumbReleaseCalendar]",
+	"one = \"Calendr datganiadau\"",
+	"[BreadcrumbCancelled]",
+	"one = \"Canslwyd\"",
+}
+
+var enLocale = []string{
+	"[ReleasedAfter]",
+	"one = \"Released after\"",
+	"[ReleasedBefore]",
+	"one = \"Released before\"",
+	"[DateFilterDescription]",
+	"one=\"For example: 2006 or 19/07/2010\"",
+	"[ReleaseCalendarPageTitle]",
+	"one=\"Release Calendar\"",
+	"[BreadcrumbHome]",
+	"one=\"Home\"",
+	"[BreadcrumbReleaseCalendar]",
+	"one = \"Release calendar\"",
+	"[BreadcrumbCancelled]",
+	"one = \"Cancelled\"",
+}
+
 func MockAssetFunction(name string) ([]byte, error) {
 	if strings.Contains(name, ".cy.toml") {
-		return []byte("[ReleasedAfter]\none = \"Cyhoeddwyd ar ôl\"\n[ReleasedBefore]\none = \"Cyhoeddwyd cyn\"\n[DateFilterDescription]\none=\"Er enghraifft: 2006 neu 19/07/2010\"\n[ReleaseCalendarPageTitle]\none=\"Release Calendar in Welsh\""), nil
+		return []byte(strings.Join(cyLocale, "\n")), nil
 	}
-	return []byte("[ReleasedAfter]\none = \"Released after\"\n[ReleasedBefore]\none = \"Released before\"\n[DateFilterDescription]\none=\"For example: 2006 or 19/07/2010\"\n[ReleaseCalendarPageTitle]\none=\"Release Calendar\""), nil
+	return []byte(strings.Join(enLocale, "\n")), nil
 }


### PR DESCRIPTION
### What

Release page breadcrumb trail now has
- localisation (apart from the release title itself which is at the mercy of the data source)
- correct links to the page hierarchy

English

<img width="457" alt="Screenshot 2022-04-29 at 15 55 36" src="https://user-images.githubusercontent.com/912770/165970694-89c1cb92-b291-41d7-8bf1-2bc3329155ab.png">

Welsh

<img width="471" alt="Screenshot 2022-04-29 at 15 55 14" src="https://user-images.githubusercontent.com/912770/165970763-01595b8c-dd78-446f-8126-d09dd532f68e.png">

### How to review

- Run dp-design-system in a separate shell with `make debug`
- Run this frontend controller with `make debug`
- Within the search results, click on a title to see the Release page
- Verify that the breadcrumbs work as expected and localise correctly

### Who can review

Frontend / design system developers
