### PR TITLE
Localise Release page type

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -159,3 +159,7 @@ one = "Ar ddod"
 [BreadcrumbCancelled]
 description = "Cancelled"
 one = "Canslwyd"
+
+[ReleasePageType]
+description = "Release"
+one = "Datganiad"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -159,3 +159,7 @@ one = "Upcoming"
 [BreadcrumbCancelled]
 description = "Cancelled"
 one = "Cancelled"
+
+[ReleasePageType]
+description = "Release"
+one = "Release"

--- a/assets/templates/release.tmpl
+++ b/assets/templates/release.tmpl
@@ -1,8 +1,12 @@
 <div class="ons-page__container ons-container">
   {{ template "partials/breadcrumb" . }}
 
-  <div class="ons-u-fs-m ons-u-mt-s">Release</div>
-  <h1 class="ons-u-fs-xxxl ons-u-mt-s">{{ .Page.Metadata.Title }}</h1>
+  <div class="ons-u-fs-m ons-u-mt-s">
+    {{- localise "ReleasePageType" .Language 1 -}}
+  </div>
+  <h1 class="ons-u-fs-xxxl ons-u-mt-s">
+    {{- .Page.Metadata.Title -}}
+  </h1>
 
   {{ template "partials/release/status-header" . }}
   {{ template "partials/release/contents" . }}


### PR DESCRIPTION
### What

Localise Release page type

English

<img width="451" alt="Screenshot 2022-04-29 at 16 34 33" src="https://user-images.githubusercontent.com/912770/165977008-47bc622f-7b2d-44db-9eff-32c0e2c16869.png">

Welsh

<img width="459" alt="Screenshot 2022-04-29 at 16 34 15" src="https://user-images.githubusercontent.com/912770/165977023-b351c38c-8a85-4988-baff-e400c7bba8af.png">

### How to review

- Run dp-design-system in a separate shell with `make debug`
- Run this frontend controller with `make debug`
- Within the search results, click on a title to see the Release page
- Verify that the page type is localised

### Who can review

Frontend / design system developers
