### PR TITLE
Localise release page subsections and other headings

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -140,6 +140,42 @@ one = "Hanes datganiadau"
 description = "Code of Practice for Official Statistics"
 one = "Y Cod Ymarfer ar gyfer Ystadegau Swyddogol"
 
+[ReleaseSubsectionName]
+description = "Name"
+one = "Enw"
+
+[ReleaseSubsectionEmail]
+description = "Email"
+one = "E-bost"
+
+[ReleaseSubsectionPhone]
+description = "Phone"
+one = "Ffôn"
+
+[ReleaseSubsectionPreviousDate]
+description = "Previous date"
+one = "Dyddiad blaenorol"
+
+[ReleaseSubsectionReasonForChange]
+description = "Reason for change"
+one = "Rheswm dros newid"
+
+[ReleaseHistoryReleaseDate]
+description = "Release date"
+one = "Dyddiad y datganiad"
+
+[ReleaseHistoryReasonForUpdate]
+description = "Reason for update"
+one = "Rheswm dros ddiweddaru"
+
+[ReleaseHistoryLatest]
+description = "LATEST"
+one = "DIWEDDARAF"
+
+[ReleaseHistoryAllPrevious]
+description = "See all previous releases"
+one = "Gweld pob datganiad blaenorol"
+
 [BreadcrumbHome]
 description = "Home"
 one = "Hafan"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -140,6 +140,42 @@ one = "Release history"
 description = "Code of Practice for Official Statistics"
 one = "Code of Practice for Official Statistics"
 
+[ReleaseSubsectionName]
+description = "Name"
+one = "Name"
+
+[ReleaseSubsectionEmail]
+description = "Email"
+one = "Email"
+
+[ReleaseSubsectionPhone]
+description = "Phone"
+one = "Phone"
+
+[ReleaseSubsectionPreviousDate]
+description = "Previous date"
+one = "Previous date"
+
+[ReleaseSubsectionReasonForChange]
+description = "Reason for change"
+one = "Reason for change"
+
+[ReleaseHistoryReleaseDate]
+description = "Release date"
+one = "Release date"
+
+[ReleaseHistoryReasonForUpdate]
+description = "Reason for update"
+one = "Reason for update"
+
+[ReleaseHistoryLatest]
+description = "LATEST"
+one = "LATEST"
+
+[ReleaseHistoryAllPrevious]
+description = "See all previous releases"
+one = "See all previous releases"
+
 [BreadcrumbHome]
 description = "Home"
 one = "Home"

--- a/assets/templates/partials/release/contents/contact-details.tmpl
+++ b/assets/templates/partials/release/contents/contact-details.tmpl
@@ -1,10 +1,18 @@
 <div>
-  <h3>Name</h3>
+  <h3>{{ localise "ReleaseSubsectionName" .Language 1 }}</h3>
   <p>{{ .Description.Contact.Name }}</p>
 
-  <h3>Email</h3>
-  <p><a href="mailto:{{ .Description.Contact.Email }}">{{ .Description.Contact.Email }}</a></p>
+  <h3>{{ localise "ReleaseSubsectionEmail" .Language 1 }}</h3>
+  <p>
+    <a href="mailto:{{ .Description.Contact.Email }}">
+      {{- .Description.Contact.Email -}}
+    </a>
+  </p>
 
-  <h3>Phone</h3>
-  <p><a href="tel:{{ .Description.Contact.Telephone }}">{{ .Description.Contact.Telephone }}</a></p>
+  <h3>{{ localise "ReleaseSubsectionPhone" .Language 1 }}</h3>
+  <p>
+    <a href="tel:{{ .Description.Contact.Telephone }}">
+      {{- .Description.Contact.Telephone -}}
+    </a>
+  </p>
 </div>

--- a/assets/templates/partials/release/contents/date-changes.tmpl
+++ b/assets/templates/partials/release/contents/date-changes.tmpl
@@ -1,10 +1,10 @@
 <ol class="ons-list ons-list--bare">
   {{ range .DateChanges }}
     <li class="ons-list__item">
-        <h3>Previous date</h3>
+        <h3>{{ localise "ReleaseSubsectionPreviousDate" $.Language 1 }}</h3>
         <p>{{ .Date }}</p>
 
-        <h3>Reason for change</h3>
+        <h3>{{ localise "ReleaseSubsectionReasonForChange" $.Language 1 }}</h3>
         <p>{{ .ChangeNotice }}</p>
     </li>
   {{ end }}

--- a/assets/templates/partials/release/contents/release-history.tmpl
+++ b/assets/templates/partials/release/contents/release-history.tmpl
@@ -4,10 +4,10 @@
     <thead class="ons-table__head">
       <tr class="ons-table__row">
         <th scope="col" class="ons-table__header">
-          <span>Release date</span>
+          <span>{{ localise "ReleaseHistoryReleaseDate" .Language 1 }}</span>
         </th>
         <th scope="col" class="ons-table__header">
-          <span>Reason for update</span>
+          <span>{{ localise "ReleaseHistoryReasonForUpdate" .Language 1 }}</span>
         </th>
       </tr>
     </thead>
@@ -18,7 +18,7 @@
             {{ if eq $index 0 }}
               {{ $element.Title }}
               <span class="sticker ons-u-fs-s--b">
-                LATEST
+                {{- localise "ReleaseHistoryLatest" $.Language 1 -}}
               </span>
             {{ else }}
               <a href="{{ $element.URI }}">{{ $element.Title }}</a>
@@ -33,6 +33,6 @@
   </table>
 
   <div class="ons-u-mb-s">
-    <a href="">See all previous releases</a>
+    <a href="">{{ localise "ReleaseHistoryAllPrevious" .Language 1 }}</a>
   </div>
 </div>


### PR DESCRIPTION
### What

Localisation of Release page subsection headings, for example Name and Email within the Contact Details section.

English

![Screenshot 2022-05-04 at 15 39 54](https://user-images.githubusercontent.com/912770/166706118-c157156b-dce7-4a66-ab93-1e1e395c6681.png)

Welsh

![Screenshot 2022-05-04 at 15 39 40](https://user-images.githubusercontent.com/912770/166706166-1369b00f-931a-4e2b-b793-e2dbdeb4992d.png)


### How to review

- In a separate shell run dp-design-system with `make debug`
- Run this frontend controller with `make debug`
- On the Release Calendar, click on a Release
- (find a Release that has Contact Details and Changes To This Release Date sections)
- Observe localisation of subheadings

### Who can review

Frontend / design system developers
