### PR TITLE
Use ONS Date Pattern to format timestamps in date changes

### DIFF
--- a/assets/templates/partials/release/contents/date-changes.tmpl
+++ b/assets/templates/partials/release/contents/date-changes.tmpl
@@ -2,7 +2,7 @@
   {{ range .DateChanges }}
     <li class="ons-list__item">
         <h3>{{ localise "ReleaseSubsectionPreviousDate" $.Language 1 }}</h3>
-        <p>{{ .Date }}</p>
+        <p>{{ dateTimeOnsDatePatternFormat .Date }}</p>
 
         <h3>{{ localise "ReleaseSubsectionReasonForChange" $.Language 1 }}</h3>
         <p>{{ .ChangeNotice }}</p>


### PR DESCRIPTION
### What

Apply friendly format to timestamps in "Changes to this release date"

<img width="514" alt="Screenshot 2022-05-09 at 14 11 41" src="https://user-images.githubusercontent.com/912770/167417592-be809eb7-dfa7-4d84-98ff-0558e303a4ec.png">

### How to review

- Run dp-design-system in separate shell with `make debug`
- Run this frontend controller with `make debug`
- Find a Release with a date change history that will show the "Changes to release date" section
- Verify that the date and time of the change(s) are shown in ONS Date Pattern format.

### Who can review

Frontend / design system developers
