### PR TITLE
Use ONS Date Pattern to format release status timestamps

### DIFF
--- a/assets/templates/partials/release/status-header.tmpl
+++ b/assets/templates/partials/release/status-header.tmpl
@@ -1,30 +1,36 @@
 {{ if .Description.ProvisionalDate }}
   <div>
-    <span class="ons-u-fs-r--b">Provisional release date:</span> {{ .Description.ProvisionalDate }}
+    <span class="ons-u-fs-r--b">Provisional release date:</span>
+    {{/* ProvisionalDate is a free text field in Florence, not a timestamp */}}
+    <span>{{ .Description.ProvisionalDate }}</span>
   </div>
 {{ else if .Description.Cancelled }}
   <div>
-    <span class="ons-u-fs-r--b">Release date:</span> Cancelled
+    <span class="ons-u-fs-r--b">Release date:</span>
+    <span>Cancelled</span>
   </div>
 {{ else if .Description.NextRelease }}
   <div class="ons-grid ons-u-ml-no">
     <!-- Left column -->
     <div class="ons-grid__col ons-col-4@m ons-u-p-no">
       <div class="ons-pl-grid-col">
-        <span class="ons-u-fs-r--b">Released:</span> {{ .Description.ReleaseDate }}
+        <span class="ons-u-fs-r--b">Released:</span>
+        <span>{{ dateTimeOnsDatePatternFormat .Description.ReleaseDate }}</span>
       </div>
     </div>
 
     <!-- Right column -->
     <div class="ons-grid__col ons-col-8@m">
       <div class="ons-pl-grid-col">
-        <span class="ons-u-fs-r--b">Next release:</span> {{ .Description.NextRelease }}
+        <span class="ons-u-fs-r--b">Next release:</span>
+        <span>{{ dateTimeOnsDatePatternFormat .Description.NextRelease }}</span>
       </div>
     </div>
   </div>
 {{ else }}
   <div>
-    <span class="ons-u-fs-r--b">Release date:</span> {{ .Description.ReleaseDate }}
+    <span class="ons-u-fs-r--b">Release date:</span>
+    <span>{{ dateTimeOnsDatePatternFormat .Description.ReleaseDate }}</span>
   </div>
 {{ end }}
 


### PR DESCRIPTION
### What

"Release date", "Released", and "Next release" use friendly formatting of timestamps. 

<img width="514" alt="Screenshot 2022-05-09 at 14 56 17" src="https://user-images.githubusercontent.com/912770/167426250-e48beb7e-9697-4b97-969f-3dfed216f9ba.png">

<img width="701" alt="Screenshot 2022-05-09 at 14 56 48" src="https://user-images.githubusercontent.com/912770/167426261-f3796283-cb9c-4a50-8d81-852644da2f5a.png">

### How to review

- Run dp-design-system in a separate shell with `make debug`
- Run this frontend controller with `make debug`
- Find a Release in each of the states that would allow testing of "Release date", "Released", and "Next release"
- Verify that the timestamps in these fields are displayed using ONS Date Pattern format

### Who can review

Frontend / design system developers
