### PR TITLE
Import dp-renderer v1.26.1; drop Release title from breadcrumbs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.104.0
 	github.com/ONSdigital/dp-healthcheck v1.2.3
 	github.com/ONSdigital/dp-net/v2 v2.0.0
-	github.com/ONSdigital/dp-renderer v1.26.0
+	github.com/ONSdigital/dp-renderer v1.26.1
 	github.com/ONSdigital/log.go/v2 v2.1.0
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/ONSdigital/dp-renderer v1.25.4 h1:2vuM9wYaYMHSDPtfv+SrKSlgsp2HlNUB4Tx
 github.com/ONSdigital/dp-renderer v1.25.4/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/dp-renderer v1.26.0 h1:jVB0adtXsoCaTir8+mlm61UvG1j5nJAHjxBk2vGfH6I=
 github.com/ONSdigital/dp-renderer v1.26.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
+github.com/ONSdigital/dp-renderer v1.26.1 h1:AKhExqbgaoE46SUXJ/9SCAlsxtxnJ7tpP9R94sKUgcQ=
+github.com/ONSdigital/dp-renderer v1.26.1/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -201,9 +201,6 @@ func mapBreadcrumbTrail(description model.ReleaseDescription, language string) [
 			Title: helper.Localise(localeKey, language, 1),
 			URI:   fmt.Sprintf("/releasecalendar?release-type=%s", releaseType.String()),
 		},
-		{
-			Title: description.Title,
-		},
 	}
 }
 

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -152,8 +152,6 @@ func TestUnitMapper(t *testing.T) {
 				{
 					Title: "Cancelled",
 					URI:   "/releasecalendar?release-type=type-cancelled",
-				}, {
-					Title: "Release title",
 				},
 			})
 		})


### PR DESCRIPTION
### What

Release breadcrumbs now render like this, sidestepping the long Release title name and restoring the navigation on mobile.

Desktop

<img width="863" alt="Screenshot 2022-05-09 at 17 00 49" src="https://user-images.githubusercontent.com/912770/167642418-7f81976c-aed8-4be9-bf59-67a68c548a87.png">

Mobile:

<img width="373" alt="Screenshot 2022-05-09 at 17 00 38" src="https://user-images.githubusercontent.com/912770/167642435-39be2b2e-5ad0-4dfe-a407-b3f813f3f5ad.png">

### How to review

- Run the dp-design-system in a separate shell with `make debug`
- Run this frontend controller with `make debug`
- Select a Release (with any title, long or short)
- Verify that the breadcrumb trail omits the Release title
- Verify that the desktop and mobile views both offer a working navigation link that takes the user back a level in the site hierarchy


### Who can review

Frontend / design system developers
