### PR TITLE
Language in Release Calendar and Release set by dp-net

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -42,7 +42,7 @@ func Release(cfg config.Config, rc RenderClient, api ReleaseCalendarAPI) http.Ha
 		}
 
 		basePage := rc.NewBasePageModel()
-		m := mapper.CreateRelease(basePage, *release)
+		m := mapper.CreateRelease(basePage, *release, lang)
 
 		rc.BuildPage(w, m, "release")
 	})
@@ -88,7 +88,7 @@ func ReleaseCalendar(cfg config.Config, rc RenderClient, api SearchAPI) http.Han
 		}
 
 		basePage := rc.NewBasePageModel()
-		calendar := mapper.CreateReleaseCalendar(basePage, validatedParams, releases, cfg)
+		calendar := mapper.CreateReleaseCalendar(basePage, validatedParams, releases, cfg, lang)
 
 		rc.BuildPage(w, calendar, "calendar")
 	})

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -118,7 +118,7 @@ func createTableOfContents(
 	return toc
 }
 
-func CreateRelease(basePage coreModel.Page, release releasecalendar.Release) model.Release {
+func CreateRelease(basePage coreModel.Page, release releasecalendar.Release, lang string) model.Release {
 	result := model.Release{
 		Page:     basePage,
 		Markdown: release.Markdown,
@@ -140,7 +140,7 @@ func CreateRelease(basePage coreModel.Page, release releasecalendar.Release) mod
 			ProvisionalDate:    release.Description.ProvisionalDate,
 		},
 	}
-
+	result.Language = lang
 	result.RelatedDatasets = mapLink(release.RelatedDatasets)
 	result.RelatedDocuments = mapLink(release.RelatedDocuments)
 	result.RelatedMethodology = mapLink(release.RelatedMethodology)
@@ -219,10 +219,11 @@ func mapLink(links []releasecalendar.Link) []model.Link {
 	return res
 }
 
-func CreateReleaseCalendar(basePage coreModel.Page, params queryparams.ValidatedParams, response search.ReleaseResponse, cfg config.Config) model.Calendar {
+func CreateReleaseCalendar(basePage coreModel.Page, params queryparams.ValidatedParams, response search.ReleaseResponse, cfg config.Config, lang string) model.Calendar {
 	calendar := model.Calendar{
 		Page: basePage,
 	}
+	calendar.Language = lang
 	calendar.BetaBannerEnabled = true
 	calendar.Metadata.Title = helper.Localise("ReleaseCalendarPageTitle", calendar.Language, 1)
 	calendar.KeywordSearch = coreModel.CompactSearch{

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -114,7 +114,11 @@ func TestUnitMapper(t *testing.T) {
 		}
 
 		Convey("CreateRelease maps correctly to a model object", func() {
-			model := CreateRelease(basePage, release, "")
+			lang := "cy"
+			crumbLabelHome := "Hafan"
+			crumbLabelReleaseCalendar := "Calendr datganiadau"
+			crumbLabelCancelled := "Canslwyd"
+			model := CreateRelease(basePage, release, lang)
 
 			So(model.PatternLibraryAssetsPath, ShouldEqual, basePage.PatternLibraryAssetsPath)
 			So(model.SiteDomain, ShouldEqual, basePage.SiteDomain)
@@ -142,15 +146,15 @@ func TestUnitMapper(t *testing.T) {
 			So(model.Description.ProvisionalDate, ShouldEqual, release.Description.ProvisionalDate)
 			So(model.Breadcrumb, ShouldResemble, []coreModel.TaxonomyNode{
 				{
-					Title: "Home",
+					Title: crumbLabelHome,
 					URI:   "/",
 				},
 				{
-					Title: "Release calendar",
+					Title: crumbLabelReleaseCalendar,
 					URI:   "/releasecalendar",
 				},
 				{
-					Title: "Cancelled",
+					Title: crumbLabelCancelled,
 					URI:   "/releasecalendar?release-type=type-cancelled",
 				}, {
 					Title: "Release title",
@@ -252,16 +256,18 @@ func TestReleaseCalendarMapper(t *testing.T) {
 		cfg := config.Config{DefaultMaximumSearchResults: 1000}
 
 		Convey("CreateReleaseCalendar maps correctly to a model Calendar object", func() {
-			calendar := CreateReleaseCalendar(basePage, params, releaseResponse, cfg, "")
+			lang := "cy"
+			metaTitle := "Calendr datganiadau"
+			calendar := CreateReleaseCalendar(basePage, params, releaseResponse, cfg, lang)
 
 			So(calendar.PatternLibraryAssetsPath, ShouldEqual, basePage.PatternLibraryAssetsPath)
 			So(calendar.SiteDomain, ShouldEqual, basePage.SiteDomain)
 			So(calendar.BetaBannerEnabled, ShouldBeTrue)
-			So(calendar.Metadata.Title, ShouldEqual, "Release Calendar")
+			So(calendar.Metadata.Title, ShouldEqual, metaTitle)
 			So(calendar.KeywordSearch.SearchTerm, ShouldEqual, params.Keywords)
 			So(calendar.Sort, ShouldResemble, model.Sort{Mode: params.Sort.String(), Options: mapSortOptions(params)})
 			So(calendar.BeforeDate, ShouldResemble, coreModel.InputDate{
-				Language:        basePage.Language,
+				Language:        lang,
 				Id:              "before-date",
 				InputNameDay:    "before-day",
 				InputNameMonth:  "before-month",
@@ -279,7 +285,7 @@ func TestReleaseCalendarMapper(t *testing.T) {
 				},
 			})
 			So(calendar.AfterDate, ShouldResemble, coreModel.InputDate{
-				Language:        basePage.Language,
+				Language:        lang,
 				Id:              "after-date",
 				InputNameDay:    "after-day",
 				InputNameMonth:  "after-month",
@@ -296,7 +302,7 @@ func TestReleaseCalendarMapper(t *testing.T) {
 					Plural:    1,
 				},
 			})
-			So(calendar.ReleaseTypes, ShouldResemble, mapReleases(params, releaseResponse, ""))
+			So(calendar.ReleaseTypes, ShouldResemble, mapReleases(params, releaseResponse, lang))
 			So(calendar.Pagination.TotalPages, ShouldEqual, 3)
 			So(calendar.Pagination.CurrentPage, ShouldEqual, 1)
 			So(calendar.Pagination.Limit, ShouldEqual, 5)

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -114,7 +114,7 @@ func TestUnitMapper(t *testing.T) {
 		}
 
 		Convey("CreateRelease maps correctly to a model object", func() {
-			model := CreateRelease(basePage, release)
+			model := CreateRelease(basePage, release, "")
 
 			So(model.PatternLibraryAssetsPath, ShouldEqual, basePage.PatternLibraryAssetsPath)
 			So(model.SiteDomain, ShouldEqual, basePage.SiteDomain)
@@ -252,7 +252,7 @@ func TestReleaseCalendarMapper(t *testing.T) {
 		cfg := config.Config{DefaultMaximumSearchResults: 1000}
 
 		Convey("CreateReleaseCalendar maps correctly to a model Calendar object", func() {
-			calendar := CreateReleaseCalendar(basePage, params, releaseResponse, cfg)
+			calendar := CreateReleaseCalendar(basePage, params, releaseResponse, cfg, "")
 
 			So(calendar.PatternLibraryAssetsPath, ShouldEqual, basePage.PatternLibraryAssetsPath)
 			So(calendar.SiteDomain, ShouldEqual, basePage.SiteDomain)


### PR DESCRIPTION
### What

<img width="202" alt="Screenshot 2022-05-12 at 13 10 30" src="https://user-images.githubusercontent.com/912770/168071660-0601c591-06f5-4e4d-a183-833d6629d1a3.png">

Enable the language switch in the header.

Also enables cookie control of language (useful for development and testing on localhost)
Cookie name: lang
Cookie value: en or cy

### How to review

Set the cookie and reload the page, or deploy into develop to test with domain switching e.g. "develop.ons.gov.uk" vs "cy.develop.ons.gov.uk"

### Who can review

Anyone
