### PR TITLE
Hide RSS link

### DIFF
--- a/assets/templates/partials/calendar/items/subscription-links.tmpl
+++ b/assets/templates/partials/calendar/items/subscription-links.tmpl
@@ -1,6 +1,7 @@
 <div class="ons-u-bt ons-u-mt-l ons-u-mb-l">
   <ul class="ons-list ons-list--bare ons-list--icons ons-list--inline@l ons-u-fs-s ons-u-mt-s ons-u-mb-s ons-u-ml-no ons-u-mr-no ons-u-flex-ai-b">
-    <li class="ons-list__item">
+    {{/* TODO Remove ons-u-d-no to reinstate RSS link */}}
+    <li class="ons-list__item ons-u-d-no">
       <span class="ons-list__prefix" aria-hidden="true">
         <img
           class="ons-svg-icon ons-u-d-b"


### PR DESCRIPTION
### What

RSS link is hidden for Release Calendar MVP. To be reinstated at a later date.

Desktop:

<img width="1112" alt="Screenshot 2022-05-16 at 10 24 39" src="https://user-images.githubusercontent.com/912770/168563130-0bdfcb5f-16fc-4cfd-8a70-17cd323d8395.png">

Mobile:

<img width="376" alt="Screenshot 2022-05-16 at 10 24 26" src="https://user-images.githubusercontent.com/912770/168563138-c4874af9-0118-4682-8b87-0ce1f8b4b921.png">


### How to review

- Run dp-design-system in a separate shell with `make debug`
- Run this frontend with `make debug`
- Verify that the RSS link is hidden

### Who can review

Anyone
