### PR TITLE
National Statistics logo links to UKSA definition

### DIFF
--- a/assets/templates/partials/release/contents/about-the-data.tmpl
+++ b/assets/templates/partials/release/contents/about-the-data.tmpl
@@ -23,14 +23,19 @@
     </div>
   {{ end }}
   {{ if .Description.NationalStatistic }}
-    <div class="ons-u-mb-l national-statistic">
+    <div class="ons-u-mb-l national-statistics">
       <h2 class="ons-u-fs-l">
         <span>Code of Practice for Statistics content</span>
-        <img
-          src="https://cdn.ons.gov.uk/assets/images/ons-logo/kitemark/uksa-kitemark.svg"
-          alt="UK Statistics Authority kitemark"
-          class="ons-u-ml-s"
+        <a
+          href="https://uksa.statisticsauthority.gov.uk/about-the-authority/uk-statistical-system/types-of-official-statistics/"
+          class="national-statistics__link ons-u-ml-s"
         >
+          <img
+            src="https://cdn.ons.gov.uk/assets/images/ons-logo/kitemark/uksa-kitemark.svg"
+            alt="UK Statistics Authority kitemark"
+            class="national-statistics__logo"
+          >
+        </a>
       </h2>
       <p>
         These National Statistics have been independently assessed by the UK

--- a/assets/templates/release.tmpl
+++ b/assets/templates/release.tmpl
@@ -7,11 +7,16 @@
   <h1 class="ons-u-fs-xxxl ons-u-mt-s">
     <span>{{- .Page.Metadata.Title -}}</span>
     {{ if .Description.NationalStatistic }}
-      <img
-        src="https://cdn.ons.gov.uk/assets/images/ons-logo/kitemark/uksa-kitemark.svg"
-        alt="UK Statistics Authority kitemark"
-        class="ons-u-ml-s"
+      <a
+        href="https://uksa.statisticsauthority.gov.uk/about-the-authority/uk-statistical-system/types-of-official-statistics/"
+        class="national-statistics__link ons-u-ml-s"
       >
+        <img
+          src="https://cdn.ons.gov.uk/assets/images/ons-logo/kitemark/uksa-kitemark.svg"
+          alt="UK Statistics Authority kitemark"
+          class="national-statistics__logo"
+        >
+      </a>
     {{ end }}
   </h1>
 

--- a/config/config.go
+++ b/config/config.go
@@ -41,7 +41,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/e9dc639"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/8324f37"
 	}
 
 	cfg.PrivateRoutingPrefix = validatePrivatePrefix(cfg.PrivateRoutingPrefix)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,7 +22,7 @@ func TestConfig(t *testing.T) {
 			Convey("Then the values should be set to the expected defaults", func() {
 				So(cfg.Debug, ShouldBeFalse)
 				So(cfg.BindAddr, ShouldEqual, ":27700")
-				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/e9dc639")
+				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/8324f37")
 				So(cfg.SupportedLanguages, ShouldResemble, []string{"en", "cy"})
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)


### PR DESCRIPTION
### What

Both instances of the National Statistics logo on a Release page now link to https://uksa.statisticsauthority.gov.uk/about-the-authority/uk-statistical-system/types-of-official-statistics/

![Screenshot 2022-05-18 at 13 43 53](https://user-images.githubusercontent.com/912770/169041562-5fc7b04f-9571-4cfd-bfcc-fa235edb419a.png)

![Screenshot 2022-05-18 at 13 43 58](https://user-images.githubusercontent.com/912770/169041574-832ad3ab-cba0-4a1d-9e17-d947befefe0c.png)


### How to review

- In a separate shell, run dp-design-system with `make debug`
- Run this frontend controller with `make debug`
- Click on a Release that has National Statistics branding
- Verify that both National Statistics logos link to the external resource mentioned above

### Who can review

Frontend / design system developers
