### PR TITLE
Feature/zero results messaging for release calendar

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -253,13 +253,13 @@ description = "No releases found"
 one = "Heb ddod o hyd i unrhyw ddatganiadau"
 
 [NoReleasesFoundDescriptionPublished]
-description = "No Releases Found Description"
+description = "No Releases Found Description Published"
 one = "Nid oes unrhyw ddatganiadau cyhoeddedig. Ceisiwch ddewis math gwahanol o ddatganiad."
 
 [NoReleasesFoundDescriptionUpcoming]
-description = "No Releases Found Description"
+description = "No Releases Found Description Upcoming"
 one = "Nid oes unrhyw ddatganiadau sydd ar ddod. Ceisiwch ddewis math gwahanol o ddatganiad."
 
 [NoReleasesFoundDescriptionCancelled]
-description = "No Releases Found Description"
+description = "No Releases Found Description Cancelled"
 one = "Nid oes unrhyw ddatganiadau a ganslwyd. Ceisiwch ddewis math gwahanol o ddatganiad."

--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -247,3 +247,11 @@ one = "Gohiriwyd"
 [ReleaseStateCancelled]
 description = "Cancelled"
 one = "Canslwyd"
+
+[NoReleasesFound]
+description = "No releases found"
+one = "No releases found [cy]"
+
+[NoReleasesFoundDescription]
+description = "No Releases Found Description"
+one = "There are no cancelled releases. Try selecting a different type of release. [cy]"

--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -250,8 +250,16 @@ one = "Canslwyd"
 
 [NoReleasesFound]
 description = "No releases found"
-one = "No releases found [cy]"
+one = "Heb ddod o hyd i unrhyw ddatganiadau"
 
-[NoReleasesFoundDescription]
+[NoReleasesFoundDescriptionPublished]
 description = "No Releases Found Description"
-one = "There are no cancelled releases. Try selecting a different type of release. [cy]"
+one = "Nid oes unrhyw ddatganiadau cyhoeddedig. Ceisiwch ddewis math gwahanol o ddatganiad."
+
+[NoReleasesFoundDescriptionUpcoming]
+description = "No Releases Found Description"
+one = "Nid oes unrhyw ddatganiadau sydd ar ddod. Ceisiwch ddewis math gwahanol o ddatganiad."
+
+[NoReleasesFoundDescriptionCancelled]
+description = "No Releases Found Description"
+one = "Nid oes unrhyw ddatganiadau a ganslwyd. Ceisiwch ddewis math gwahanol o ddatganiad."

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -252,7 +252,15 @@ one = "Cancelled"
 description = "No releases found"
 one = "No releases found"
 
-[NoReleasesFoundDescription]
+[NoReleasesFoundDescriptionPublished]
+description = "No Releases Found Description"
+one = "There are no published releases. Try selecting a different type of release."
+
+[NoReleasesFoundDescriptionUpcoming]
+description = "No Releases Found Description"
+one = "There are no upcoming releases. Try selecting a different type of release."
+
+[NoReleasesFoundDescriptionCancelled]
 description = "No Releases Found Description"
 one = "There are no cancelled releases. Try selecting a different type of release."
 

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -253,14 +253,14 @@ description = "No releases found"
 one = "No releases found"
 
 [NoReleasesFoundDescriptionPublished]
-description = "No Releases Found Description"
+description = "No Releases Found Description Published"
 one = "There are no published releases. Try selecting a different type of release."
 
 [NoReleasesFoundDescriptionUpcoming]
-description = "No Releases Found Description"
+description = "No Releases Found Description Upcoming"
 one = "There are no upcoming releases. Try selecting a different type of release."
 
 [NoReleasesFoundDescriptionCancelled]
-description = "No Releases Found Description"
+description = "No Releases Found Description Cancelled"
 one = "There are no cancelled releases. Try selecting a different type of release."
 

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -247,3 +247,12 @@ one = "Postponed"
 [ReleaseStateCancelled]
 description = "Cancelled"
 one = "Cancelled"
+
+[NoReleasesFound]
+description = "No releases found"
+one = "No releases found"
+
+[NoReleasesFoundDescription]
+description = "No Releases Found Description"
+one = "There are no cancelled releases. Try selecting a different type of release."
+

--- a/assets/templates/partials/calendar/items.tmpl
+++ b/assets/templates/partials/calendar/items.tmpl
@@ -1,6 +1,10 @@
 <div class="ons-pl-grid-col">
   {{ template "partials/calendar/items/sort-by" .}}
-  {{ template "partials/calendar/items/list" .}}
-  {{ template "partials/pagination" . }}
-  {{ template "partials/calendar/items/subscription-links" .}}
+  {{ if eq (len .Entries) 0 }}
+    {{ template "partials/calendar/items/no-result-found" .}}
+  {{ else }}
+    {{ template "partials/calendar/items/list" .}}
+    {{ template "partials/pagination" . }}
+    {{ template "partials/calendar/items/subscription-links" .}}
+  {{ end }}
 </div>

--- a/assets/templates/partials/calendar/items/no-result-found.tmpl
+++ b/assets/templates/partials/calendar/items/no-result-found.tmpl
@@ -17,6 +17,5 @@
             <p>{{- localise "NoReleasesFoundDescriptionCancelled" .Language 1 -}}</p>
         {{ end }}
     {{ end }}
-    
 </div>
 

--- a/assets/templates/partials/calendar/items/no-result-found.tmpl
+++ b/assets/templates/partials/calendar/items/no-result-found.tmpl
@@ -1,5 +1,7 @@
 <div class="ons-u-bt">
-    <h2>No releases found</h2>
-    <p>There are no cancelled releases. Try selecting a different type of release.</p>
+    <h2 class="ons-u-mt-l">
+        {{- localise "NoReleasesFound" .Language 1 -}}
+    </h2>
+    <p>{{- localise "NoReleasesFoundDescription" .Language 1 -}}</p>
 </div>
 

--- a/assets/templates/partials/calendar/items/no-result-found.tmpl
+++ b/assets/templates/partials/calendar/items/no-result-found.tmpl
@@ -1,0 +1,5 @@
+<div class="ons-u-bt">
+    <h2>No releases found</h2>
+    <p>There are no cancelled releases. Try selecting a different type of release.</p>
+</div>
+

--- a/assets/templates/partials/calendar/items/no-result-found.tmpl
+++ b/assets/templates/partials/calendar/items/no-result-found.tmpl
@@ -2,6 +2,21 @@
     <h2 class="ons-u-mt-l">
         {{- localise "NoReleasesFound" .Language 1 -}}
     </h2>
-    <p>{{- localise "NoReleasesFoundDescription" .Language 1 -}}</p>
+    {{ with index .ReleaseTypes "type-published" }}
+        {{ if .Checked }}
+            <p>{{- localise "NoReleasesFoundDescriptionPublished" .Language 1 -}}</p>
+        {{ end }}
+    {{ end }}
+    {{ with index .ReleaseTypes "type-upcoming" }}
+        {{ if .Checked }}
+            <p>{{- localise "NoReleasesFoundDescriptionUpcoming" .Language 1 -}}</p>
+        {{ end }}
+    {{ end }}
+    {{ with index .ReleaseTypes "type-cancelled" }}
+        {{ if .Checked }}
+            <p>{{- localise "NoReleasesFoundDescriptionCancelled" .Language 1 -}}</p>
+        {{ end }}
+    {{ end }}
+    
 </div>
 


### PR DESCRIPTION
### What

- Create a 'Zero Results' message/format for the following scenarios:
   - If the query requested results in a '0' count returned from the server
   - If the user has applied 'Filters' which result in '0' count returned from the server

### How to review

By changing the filter to return '0' result and then the message will shows up  

### Who can review

FD
