### PR TITLE
Markdown content in a release summary is rendered correctly

### DIFF
--- a/assets/templates/partials/release/contents/body.tmpl
+++ b/assets/templates/partials/release/contents/body.tmpl
@@ -6,7 +6,7 @@
     <section id="{{ $id }}">
       <h2>{{ $section.Title.FuncLocalise $.Language }}</h2>
       {{ if eq $id "summary"}}
-        <p>{{ $release.Description.Summary }}</p>
+        <p>{{ markdown $release.Description.Summary }}</p>
       {{ else if eq $id "publications" }}
         {{ template "partials/release/contents/publications" $release }}
       {{ else if eq $id "data" }}


### PR DESCRIPTION
### What

Markdown that was displayed verbatim:

![image](https://user-images.githubusercontent.com/912770/169363174-f0b71aff-8873-4513-8783-5772fffbd818.png)

Is now rendered with correct formatting:

<img width="694" alt="Screenshot 2022-05-19 at 18 37 17" src="https://user-images.githubusercontent.com/912770/169363234-8cc583f4-bb4a-42d1-b1f8-1f90dbfe5310.png">


### How to review

- In a separate shell, run the dp-design-system with `make debug`
- Run this frontend controller with `make debug`
- Visit this release known to contain markdown: `http://localhost:27700/releases/firstresultsfromcensus2021inenglandandwales`
- Verify that the markdown formatting is rendered as in the second screentshot

### Who can review

Anyone
