### PR TITLE
Update definition for National Statistics accreditation

### DIFF
--- a/assets/templates/partials/release/contents/about-the-data.tmpl
+++ b/assets/templates/partials/release/contents/about-the-data.tmpl
@@ -38,20 +38,18 @@
         </a>
       </h2>
       <p>
-        These National Statistics have been independently assessed by the UK
-        Statistics Authority. They have been produced by following the standards
-        set out in the <a href="https://code.statisticsauthority.gov.uk/the-code/">Code of Practice for Statistics</a>
-        and the <a href="https://www.legislation.gov.uk/ukpga/2007/18/contents">Statistics and Registration Service Act 2007</a>.
+        These statistics have been given National Statistics status by the
+        Office for Statistics Regulation. They have been produced by following
+        the standards set out in the <a href="https://code.statisticsauthority.gov.uk/the-code/">Code of Practice for Statistics</a>.
+        They meet the highest standards of trustworthiness, quality and public
+        value. This means that they:
       </p>
-      <p>
-        This means that they:
-        <ul>
-          <li>meet identified user needs</li>
-          <li>are well explained and easily accessible</li>
-          <li>are produced based on appropriate data and methods</li>
-          <li>are managed impartially and objectively in the public interest</li>
-        </ul>
-      </p>
+      <ul>
+        <li>meet identified user needs</li>
+        <li>are well explained and easily accessible</li>
+        <li>are produced based on appropriate data and methods</li>
+        <li>are managed impartially and objectively in the public interest</li>
+      </ul>
     </div>
   {{ end }}
 </div>


### PR DESCRIPTION
### What

Adopt latest wording in National Statistics definition for a Release page.

<img width="673" alt="Screenshot 2022-05-20 at 17 55 27" src="https://user-images.githubusercontent.com/912770/169576566-3f818024-a5f6-4589-81a7-409ca3403876.png">

### How to review

Describe the steps required to test the changes.

- In a separate shell, run the dp-design-system with `make debug`
- Run this frontend controller with `make debug`
- Select a Release entry that has National Statistics accreditation
- Verify that the wording matches the attached screenshot
- Verify that the link "Code of Practice for Statistics" navigates to `https://code.statisticsauthority.gov.uk/the-code/`

### Who can review

Anyone
