### PR TITLE
Localise timestamps with dp-renderer v1.32.1

### DIFF
--- a/assets/templates/partials/calendar/items/list.tmpl
+++ b/assets/templates/partials/calendar/items/list.tmpl
@@ -15,7 +15,7 @@
       </a>
       <div class="ons-u-mt-s">
         <span class="ons-u-fs-r--b">{{ localise "ReleaseDate" $.Language 1 }}:</span>
-        <span>{{ dateTimeOnsDatePatternFormat .Description.ReleaseDate }}</span>
+        <span>{{ dateTimeOnsDatePatternFormat .Description.ReleaseDate $.Language }}</span>
         <span>|</span>
         {{/* template "partials/releasestate/type" .PublicationState */}}
         {{ if eq .PublicationState.Type "published" }}

--- a/assets/templates/partials/release/contents/date-changes.tmpl
+++ b/assets/templates/partials/release/contents/date-changes.tmpl
@@ -2,7 +2,7 @@
   {{ range .DateChanges }}
     <li class="ons-list__item">
         <h3>{{ localise "ReleaseSubsectionPreviousDate" $.Language 1 }}</h3>
-        <p>{{ dateTimeOnsDatePatternFormat .Date }}</p>
+        <p>{{ dateTimeOnsDatePatternFormat .Date $.Language }}</p>
 
         <h3>{{ localise "ReleaseSubsectionReasonForChange" $.Language 1 }}</h3>
         <p>{{ .ChangeNotice }}</p>

--- a/assets/templates/partials/release/status-header.tmpl
+++ b/assets/templates/partials/release/status-header.tmpl
@@ -16,7 +16,7 @@
       <div class="ons-grid__col ons-col-4@m ons-u-p-no">
         <div class="ons-pl-grid-col">
           <span class="ons-u-fs-r--b">{{ localise "ReleaseStatusLineReleased" .Language 1 }}:</span>
-          <span>{{ dateTimeOnsDatePatternFormat .Description.ReleaseDate }}</span>
+          <span>{{ dateTimeOnsDatePatternFormat .Description.ReleaseDate .Language }}</span>
         </div>
       </div>
 
@@ -24,14 +24,14 @@
       <div class="ons-grid__col ons-col-8@m">
         <div class="ons-pl-grid-col">
           <span class="ons-u-fs-r--b">{{ localise "ReleaseStatusLineNextRelease" .Language 1 }}:</span>
-          <span>{{ dateTimeOnsDatePatternFormat .Description.NextRelease }}</span>
+          <span>{{ dateTimeOnsDatePatternFormat .Description.NextRelease .Language }}</span>
         </div>
       </div>
     </div>
   {{ else }}
     <div>
       <span class="ons-u-fs-r--b">{{ localise "ReleaseStatusLineReleaseDate" .Language 1 }}:</span>
-      <span>{{ dateTimeOnsDatePatternFormat .Description.ReleaseDate }}</span>
+      <span>{{ dateTimeOnsDatePatternFormat .Description.ReleaseDate .Language }}</span>
     </div>
   {{ end }}
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ONSdigital/dp-healthcheck v1.2.3
 	github.com/ONSdigital/dp-net v1.2.0
 	github.com/ONSdigital/dp-net/v2 v2.0.0
-	github.com/ONSdigital/dp-renderer v1.28.0
+	github.com/ONSdigital/dp-renderer v1.32.1
 	github.com/ONSdigital/log.go/v2 v2.1.0
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/ONSdigital/dp-net v1.2.0 h1:gP9pBt/J8gktYeKsb7hq6uOC2xx1tfvTorUBNXp6p
 github.com/ONSdigital/dp-net v1.2.0/go.mod h1:NinlaqcsPbIR+X7j5PXCl3UI5G2zCL041SDF6WIiiO4=
 github.com/ONSdigital/dp-net/v2 v2.0.0 h1:KD/E7KIkFI/+L5r2EANSjfP3IUz6JgB+cQwgL5ybo/k=
 github.com/ONSdigital/dp-net/v2 v2.0.0/go.mod h1:Pv/35rM5tCLYdVdIZ5KoGu2EUXv/87fWTptlVTlS5MY=
-github.com/ONSdigital/dp-renderer v1.28.0 h1:BInquwPyselv6PnkOWWwAqbabqm0XJWbPlhMwzP+wCs=
-github.com/ONSdigital/dp-renderer v1.28.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
+github.com/ONSdigital/dp-renderer v1.32.1 h1:OMtq8006DLiRVV2qHkMU1FOVyEYSdBMyN/po2IjTOgE=
+github.com/ONSdigital/dp-renderer v1.32.1/go.mod h1:odKmVudLXN9WaenfrKgGGrfmZARZFemSNtSy6gxTue8=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=


### PR DESCRIPTION
### What

Localises timestamps in:
- Release Calender results list
- Release section "Changes to this release date"
- Release status line (release data / next release date)

### How to review

- In a separate shell, run dp-design-system with `make debug`
- Run this frontend with `make debug`
- Verify that the timestamps listed above are localised when the `lang` cookie is set to `cy`

### Who can review

Frontend end / design system developers
