### PR TITLE
Release state banner displays customised and stock reasons for changes in state

### DIFF
--- a/assets/templates/partials/release/status-header.tmpl
+++ b/assets/templates/partials/release/status-header.tmpl
@@ -1,4 +1,4 @@
-<div class="ons-u-mb-xl">
+<div>
   {{ if .Description.ProvisionalDate }}
     <div>
       <span class="ons-u-fs-r--b">{{ localise "ReleaseStatusLineProvisionalReleaseDate" .Language 1 }}:</span>
@@ -34,61 +34,43 @@
       <span>{{ dateTimeOnsDatePatternFormat .Description.ReleaseDate }}</span>
     </div>
   {{ end }}
-
-  {{ if not .Description.Published }}
-    <div class="ons-panel ons-panel--info ons-panel--no-title">
-      <span class="ons-u-vh">Important information: </span>
-      <div class="ons-panel__body">
-        <p>
-          This release is not yet published
-        </p>
-      </div>
-    </div>
-  {{ end }}
-
-  {{ if and .Description.Cancelled .Description.CancellationNotice }}
-    <div class="ons-panel ons-panel--info ons-panel--no-title">
-      <span class="ons-u-vh">Important information: </span>
-      <div class="ons-panel__body">
-        {{ range .Description.CancellationNotice }}
-          <p>{{ . }}</p>
-        {{ end }}
-      </div>
-    </div>
-  {{ end }}
-
-  {{/* TODO How is 'postponed' represented in the Release model?
-    {{ if .StatusFlags.InsufficientDataPostponed }}
+  <div class="ons-u-pt-s ons-u-pb-m">
+    {{ if eq .PublicationState.Type "upcoming" }}
+      {{ if or (eq .PublicationState.SubType "provisional") (eq .PublicationState.SubType "confirmed") }}
+        <div class="ons-panel ons-panel--info ons-panel--no-title">
+          <span class="ons-u-vh">Important information: </span>
+          <div class="ons-panel__body">
+            <p>This release is not yet published</p>
+          </div>
+        </div>
+      {{ else if eq .PublicationState.SubType "postponed" }}
+        <div class="ons-panel ons-panel--info ons-panel--no-title">
+          <span class="ons-u-vh">Important information: </span>
+          <div class="ons-panel__body">
+            {{ $reason := .FuncGetPostponementReason }}
+            {{ if $reason }}
+              {{- markdown $reason -}}
+            {{ else }}
+              <p>This release has been postponed</p>
+            {{ end }}
+          </div>
+        </div>
+      {{ end }}
+    {{ else if eq .PublicationState.Type "cancelled" }}
       <div class="ons-panel ons-panel--info ons-panel--no-title">
         <span class="ons-u-vh">Important information: </span>
         <div class="ons-panel__body">
-          <p>
-            This release has been postponed as there is not enough
-            personal well-being data collected to provide robust
-            quarterly estimates.
-          </p>
+          {{ if .Description.CancellationNotice }}
+            {{ range .Description.CancellationNotice }}
+              {{- markdown . -}}
+            {{ end }}
+          {{ else }}
+            <p>This release has been cancelled</p>
+          {{ end }}
         </div>
       </div>
     {{ end }}
-  */}}
-
-  {{/* TODO How can a cancellation notice containing a link be supported?
-    {{ if .StatusFlags.MergeCancelled }}
-      <div class="ons-panel ons-panel--info ons-panel--no-title">
-        <span class="ons-u-vh">Important information: </span>
-        <div class="ons-panel__body">
-          <p>
-            This release has been cancelled as the publication is
-            being merged into one headline release titled
-            <a href="{{ .StatusFlags.MergeCancelled.URI }}">
-              {{ .StatusFlags.MergeCancelled.Title }}
-            </a>.
-          </p>
-        </div>
-      </div>
-    {{ end }}
-  */}}
-
+  </div>
   {{ if .Description.Census2021 }}
     <div class="ons-u-mt-l">
       <img

--- a/model/release.go
+++ b/model/release.go
@@ -65,3 +65,15 @@ type PreviousReleases struct {
 	Description    ReleaseDescription `json:"description"`
 	ReleaseHistory []Link             `json:"release_history"`
 }
+
+// Gets the most recent postponement reason, if available
+func (release Release) FuncGetPostponementReason() string {
+	reason := ""
+	totalDateChanges := len(release.DateChanges)
+
+	if totalDateChanges > 0 {
+		reason = release.DateChanges[totalDateChanges-1].ChangeNotice
+	}
+
+	return reason
+}

--- a/model/release_test.go
+++ b/model/release_test.go
@@ -1,0 +1,44 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/ONSdigital/dp-frontend-release-calendar/model"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestUnitReleaseModel(t *testing.T) {
+	Convey("FuncGetPostponementReason", t, func() {
+		Convey("When the release is not postponed", func() {
+			release := model.Release{}
+			So(release.FuncGetPostponementReason(), ShouldEqual, "")
+		})
+
+		Convey("When the release is postponed but has no reason", func() {
+			release := model.Release{}
+			release.DateChanges = []model.DateChange{
+				{
+					Date:         "2020-01-01T00:00:00.000Z",
+					ChangeNotice: "",
+				},
+			}
+			So(release.FuncGetPostponementReason(), ShouldEqual, "")
+		})
+
+		Convey("When the release is postponed with a reason", func() {
+			release := model.Release{}
+			reason := "Postponed due to a shortage of marmalade sandwiches"
+			release.DateChanges = []model.DateChange{
+				{
+					Date:         "2020-01-01T00:00:00.000Z",
+					ChangeNotice: "",
+				},
+				{
+					Date:         "2020-02-01T00:00:00.000Z",
+					ChangeNotice: reason,
+				},
+			}
+			So(release.FuncGetPostponementReason(), ShouldEqual, reason)
+		})
+	})
+}


### PR DESCRIPTION
### What

Upcoming-Confirmed and Upcoming-Provisional releases show the stock phrase "This release is not yet published".

Upcoming-Postponed releases will display the most recent reason from `date_changes` if present, otherwise fall back to "This release has been postponed"

Cancelled releases will display the reason from `description.cancellation_notice` if present, otherwise fall back to "This release has been cancelled".

Some examples:

A cancelled release with a single paragraph reason

<img width="1023" alt="Screenshot 2022-06-08 at 17 50 59" src="https://user-images.githubusercontent.com/912770/172673629-e808e176-e634-469a-8963-146cd8a688e9.png">

A cancelled release with a multiple paragraph reason

<img width="1052" alt="Screenshot 2022-06-08 at 17 50 39" src="https://user-images.githubusercontent.com/912770/172673817-5066a6e2-a73f-4611-958b-26f2d3a5ff59.png">

A confirmed release:

<img width="1024" alt="Screenshot 2022-06-08 at 17 51 10" src="https://user-images.githubusercontent.com/912770/172673892-11a0a927-442d-403b-84f3-3bed2e2179e8.png">

A provisional release:

<img width="1048" alt="Screenshot 2022-06-08 at 17 57 16" src="https://user-images.githubusercontent.com/912770/172674037-89c3d21d-9794-496b-86df-e9e050bef07b.png">

### How to review

- In a separate shell, run the dp-design-system with `make debug`
- Run this frontend with `make debug`
- Verify that releases in Upcoming and Cancelled states display the appropriate information notices to the user in the banner
- Verify that Published releases do not show the banner

### Who can review

Frontend / design system developers
