### PR TITLE
Localise release page state banner

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -263,3 +263,19 @@ one = "Nid oes unrhyw ddatganiadau sydd ar ddod. Ceisiwch ddewis math gwahanol o
 [NoReleasesFoundDescriptionCancelled]
 description = "No Releases Found Description Cancelled"
 one = "Nid oes unrhyw ddatganiadau a ganslwyd. Ceisiwch ddewis math gwahanol o ddatganiad."
+
+[StatusBannerImportantInformation]
+description = "Important information"
+one = "Gwybodaeth pwysig"
+
+[StatusBannerReleaseNotYetPublished]
+description = "This release is not yet published"
+one = "Nid yw'r datganiad hwn wedi'i gyhoeddi eto"
+
+[StatusBannerReleasePostponed]
+description = "This release has been postponed"
+one = "Mae'r datganiad hwn wedi cael ei ohirio"
+
+[StatusBannerReleaseCancelled]
+description = "This release has been cancelled"
+one = "Mae'r datganiad hwn wedi cael ei ganslo"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -264,3 +264,18 @@ one = "There are no upcoming releases. Try selecting a different type of release
 description = "No Releases Found Description Cancelled"
 one = "There are no cancelled releases. Try selecting a different type of release."
 
+[StatusBannerImportantInformation]
+description = "Important information"
+one = "Important information"
+
+[StatusBannerReleaseNotYetPublished]
+description = "This release is not yet published"
+one = "This release is not yet published"
+
+[StatusBannerReleasePostponed]
+description = "This release has been postponed"
+one = "This release has been postponed"
+
+[StatusBannerReleaseCancelled]
+description = "This release has been cancelled"
+one = "This release has been cancelled"

--- a/assets/templates/partials/release/status-header.tmpl
+++ b/assets/templates/partials/release/status-header.tmpl
@@ -38,34 +38,34 @@
     {{ if eq .PublicationState.Type "upcoming" }}
       {{ if or (eq .PublicationState.SubType "provisional") (eq .PublicationState.SubType "confirmed") }}
         <div class="ons-panel ons-panel--info ons-panel--no-title">
-          <span class="ons-u-vh">Important information: </span>
+          <span class="ons-u-vh">{{ localise "StatusBannerImportantInformation" .Language 1 }}: </span>
           <div class="ons-panel__body">
-            <p>This release is not yet published</p>
+            <p>{{ localise "StatusBannerReleaseNotYetPublished" .Language 1 }}</p>
           </div>
         </div>
       {{ else if eq .PublicationState.SubType "postponed" }}
         <div class="ons-panel ons-panel--info ons-panel--no-title">
-          <span class="ons-u-vh">Important information: </span>
+          <span class="ons-u-vh">{{ localise "StatusBannerImportantInformation" .Language 1 }}: </span>
           <div class="ons-panel__body">
             {{ $reason := .FuncGetPostponementReason }}
             {{ if $reason }}
               {{- markdown $reason -}}
             {{ else }}
-              <p>This release has been postponed</p>
+              <p>{{ localise "StatusBannerReleasePostponed" .Language 1 }}</p>
             {{ end }}
           </div>
         </div>
       {{ end }}
     {{ else if eq .PublicationState.Type "cancelled" }}
       <div class="ons-panel ons-panel--info ons-panel--no-title">
-        <span class="ons-u-vh">Important information: </span>
+        <span class="ons-u-vh">{{ localise "StatusBannerImportantInformation" .Language 1 }}: </span>
         <div class="ons-panel__body">
           {{ if .Description.CancellationNotice }}
             {{ range .Description.CancellationNotice }}
               {{- markdown . -}}
             {{ end }}
           {{ else }}
-            <p>This release has been cancelled</p>
+            <p>{{ localise "StatusBannerReleaseCancelled" .Language 1 }}</p>
           {{ end }}
         </div>
       </div>


### PR DESCRIPTION
### What

Localises stock phrases for release page state banner, example below.

Note that some stock phrases, for example when a release is cancelled, will be overridden if a reason for cancellation is given in Florence.

<img width="1015" alt="Screenshot 2022-06-10 at 16 11 47" src="https://user-images.githubusercontent.com/912770/173096927-13971a3a-38b2-463e-8448-a807d0dc1381.png">

### How to review

- In a separate shell, run dp-design-system with `make debug`
- Run this frontend with `make debug`
- Verify that banners are localised when setting the `lang` cookie to `en` or `cy`

### Who can review

Frontend / design system developers
