### PR TITLE
Feature/release status device layout

### DIFF
--- a/assets/templates/partials/release/status-header.tmpl
+++ b/assets/templates/partials/release/status-header.tmpl
@@ -3,7 +3,7 @@
     <div>
       <span class="ons-u-fs-r--b">{{ localise "ReleaseStatusLineProvisionalReleaseDate" .Language 1 }}:</span>
       {{/* ProvisionalDate is a free text field in Florence, not a timestamp */}}
-      <span>{{ .Description.ProvisionalDate }}</span>
+      <span class="ons-u-nowrap">{{ .Description.ProvisionalDate }}</span>
     </div>
   {{ else if .Description.Cancelled }}
     <div>

--- a/assets/templates/partials/release/status-header.tmpl
+++ b/assets/templates/partials/release/status-header.tmpl
@@ -11,23 +11,16 @@
       <span>{{ localise "ReleaseStatusLineCancelled" .Language 1 }}</span>
     </div>
   {{ else if .Description.NextRelease }}
-    <div class="ons-grid ons-u-ml-no">
-      <!-- Left column -->
-      <div class="ons-grid__col ons-col-4@m ons-u-p-no">
-        <div class="ons-pl-grid-col">
-          <span class="ons-u-fs-r--b">{{ localise "ReleaseStatusLineReleased" .Language 1 }}:</span>
-          <span>{{ dateTimeOnsDatePatternFormat .Description.ReleaseDate }}</span>
-        </div>
-      </div>
-
-      <!-- Right column -->
-      <div class="ons-grid__col ons-col-8@m">
-        <div class="ons-pl-grid-col">
-          <span class="ons-u-fs-r--b">{{ localise "ReleaseStatusLineNextRelease" .Language 1 }}:</span>
-          <span>{{ dateTimeOnsDatePatternFormat .Description.NextRelease }}</span>
-        </div>
-      </div>
-    </div>
+    <ul class="ons-list ons-list--bare ons-list--inline">
+      <li class="ons-list__item ons-u-mr-xl@xs ons-u-mb-xs@xxs@m">
+        <span class="ons-u-fs-r--b">{{ localise "ReleaseStatusLineReleased" .Language 1 }}:</span>
+        <span class="ons-u-nowrap">{{ dateTimeOnsDatePatternFormat .Description.ReleaseDate }}</span>
+      </li>
+      <li class="ons-list__item ons-u-mr-xl@xs">
+        <span class="ons-u-fs-r--b">{{ localise "ReleaseStatusLineNextRelease" .Language 1 }}:</span>
+        <span class="ons-u-nowrap">{{ dateTimeOnsDatePatternFormat .Description.NextRelease }}</span>
+      </li>
+    </ul>
   {{ else }}
     <div>
       <span class="ons-u-fs-r--b">{{ localise "ReleaseStatusLineReleaseDate" .Language 1 }}:</span>

--- a/assets/templates/partials/release/status-header.tmpl
+++ b/assets/templates/partials/release/status-header.tmpl
@@ -31,10 +31,10 @@
   {{ else }}
     <div>
       <span class="ons-u-fs-r--b">{{ localise "ReleaseStatusLineReleaseDate" .Language 1 }}:</span>
-      <span>{{ dateTimeOnsDatePatternFormat .Description.ReleaseDate }}</span>
+      <span class="ons-u-nowrap">{{ dateTimeOnsDatePatternFormat .Description.ReleaseDate }}</span>
     </div>
   {{ end }}
-  <div class="ons-u-pt-s ons-u-pb-m">
+  <div class="ons-u-pt-s ons-u-pb-m@m ons-u-pb-s@xxs@m">
     {{ if eq .PublicationState.Type "upcoming" }}
       {{ if or (eq .PublicationState.SubType "provisional") (eq .PublicationState.SubType "confirmed") }}
         <div class="ons-panel ons-panel--info ons-panel--no-title">


### PR DESCRIPTION
### What

Spacing and layout out of release date and next release date in the Release page status line.

The desktop and tablet layouts should be similar, mobile is the special case.

Desktop / English

<img width="1047" alt="Screenshot 2022-06-10 at 20 08 27" src="https://user-images.githubusercontent.com/912770/173134216-b969d293-7d8d-4e4a-b796-a16bb66b96a9.png">

Desktop / Welsh

"Next release" moves laterally to accommodate longer date strings and localisations

<img width="1045" alt="Screenshot 2022-06-10 at 20 08 12" src="https://user-images.githubusercontent.com/912770/173134258-c570cf11-6a9d-486c-a78b-a2362103b0e4.png">

Mobile / English

<img width="374" alt="Screenshot 2022-06-10 at 20 08 55" src="https://user-images.githubusercontent.com/912770/173134317-e8b08552-73ae-45ed-a1dd-b78d8179efee.png">

Mobile / Welsh

Dates that are too long move under the label instead of wrapping mid-phrase

<img width="372" alt="Screenshot 2022-06-10 at 20 09 34" src="https://user-images.githubusercontent.com/912770/173134350-cc6d6e12-12bb-4d6a-b630-70ad701a509d.png">

<img width="376" alt="Screenshot 2022-06-10 at 20 09 57" src="https://user-images.githubusercontent.com/912770/173134361-0bc3ba6a-d1aa-46c8-aeda-617db9a70da0.png">


### How to review

- In a separate shell, run dp-design-system with `make debug`
- Run this frontend with `make debug`
- Verify layout behaviour on different device sizes and localisations

### Who can review

Frontend / design system developers
