### PR TITLE
Bug/release status census positioning

### DIFF
--- a/assets/templates/partials/release/status-header.tmpl
+++ b/assets/templates/partials/release/status-header.tmpl
@@ -28,6 +28,14 @@
     </div>
   {{ end }}
   <div class="ons-u-pt-s ons-u-pb-m@m ons-u-pb-s@xxs@m">
+    {{ if .Description.Census2021 }}
+      <div class="ons-u-pb-m">
+        <img
+          src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-purple-landscape.svg"
+          alt="Census 2021 logo"
+        >
+      </div>
+    {{ end }}
     {{ if eq .PublicationState.Type "upcoming" }}
       {{ if or (eq .PublicationState.SubType "provisional") (eq .PublicationState.SubType "confirmed") }}
         <div class="ons-panel ons-panel--info ons-panel--no-title">
@@ -64,12 +72,4 @@
       </div>
     {{ end }}
   </div>
-  {{ if .Description.Census2021 }}
-    <div class="ons-u-mt-l">
-      <img
-        src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-purple-landscape.svg"
-        alt="Census 2021 logo"
-      >
-    </div>
-  {{ end }}
 </div>

--- a/assets/templates/partials/release/status-header.tmpl
+++ b/assets/templates/partials/release/status-header.tmpl
@@ -29,7 +29,11 @@
   {{ end }}
   <div class="ons-u-pt-s ons-u-pb-m@m ons-u-pb-s@xxs@m">
     {{ if .Description.Census2021 }}
-      <div class="ons-u-pb-m">
+      <div
+        {{ if or (eq .PublicationState.Type "upcoming") (eq .PublicationState.Type "cancelled") }}
+          class="ons-u-pb-m"
+        {{ end }}
+      >
         <img
           src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-purple-landscape.svg"
           alt="Census 2021 logo"


### PR DESCRIPTION
### What

Display Census logo above the banner (if present) in the Release status header.

Census logo and banner
<img width="718" alt="Screenshot 2022-06-22 at 17 16 30" src="https://user-images.githubusercontent.com/912770/175089500-0398626a-99f1-4b8f-8360-16ae764215db.png">

Only banner
<img width="691" alt="Screenshot 2022-06-22 at 17 16 52" src="https://user-images.githubusercontent.com/912770/175089514-f46485a5-4cf5-4933-968f-98abadc90548.png">

Only Census logo
<img width="684" alt="Screenshot 2022-06-22 at 17 34 29" src="https://user-images.githubusercontent.com/912770/175089533-f4a3e54a-32e5-479f-8d5d-89112a6c2c0d.png">

### How to review

- In a separate shell, run dp-design-system with `make debug`
- Run this frontend with `make debug`
- Visit release pages with different combinations of banner and logo:

Both: /releases/census2021onreleasecalendarpage
Only banner: /releases/grasshopper7
Only logo: can't find an example, need to create one in florence

### Who can review

Frontend / design system developers
