### PR TITLE
Include accordion sections in tabbing order for keyboard access

### DIFF
--- a/assets/templates/partials/calendar/filters.tmpl
+++ b/assets/templates/partials/calendar/filters.tmpl
@@ -12,7 +12,10 @@
       data-group="accordion"
       data-open="true"
     >
-      <div class="ons-collapsible__heading ons-js-collapsible-heading">
+      <div
+        class="ons-collapsible__heading ons-js-collapsible-heading"
+        tabindex="0"
+      >
         <div class="ons-collapsible__controls">
           <h2 class="ons-collapsible__title">
             {{- localise "ReleaseCalendarFilterReleaseType" .Language 1 -}}
@@ -34,7 +37,10 @@
         data-open="false"
       {{ end }}
     >
-      <div class="ons-collapsible__heading ons-js-collapsible-heading">
+      <div
+        class="ons-collapsible__heading ons-js-collapsible-heading"
+        tabindex="0"
+      >
         <div class="ons-collapsible__controls">
           <h2 class="ons-collapsible__title">
             {{- localise "ReleaseCalendarFilterSearch" .Language 1 -}}
@@ -57,7 +63,10 @@
         data-open="false"
       {{ end }}
     >
-      <div class="ons-collapsible__heading ons-js-collapsible-heading">
+      <div
+        class="ons-collapsible__heading ons-js-collapsible-heading"
+        tabindex="0"
+      >
         <div class="ons-collapsible__controls">
           <h2 class="ons-collapsible__title">
             {{- localise "ReleaseCalendarFilterDate" .Language 1 -}}


### PR DESCRIPTION
### What

Pressing the Tab key to cycle through elements on the page now includes the accordion filters.

Tabbing to "Release type" will look like this:

<img width="362" alt="Screenshot 2022-06-23 at 12 00 04" src="https://user-images.githubusercontent.com/912770/175284137-58527f7d-c7e1-41da-ad51-e7d19f4d3ed8.png">

Tabbing over to "Search" will look like this:

<img width="365" alt="Screenshot 2022-06-23 at 12 00 14" src="https://user-images.githubusercontent.com/912770/175284319-53b35635-6b3c-451a-b4f7-76ba24e47fe8.png">

Pressing space on "Search" will expand the section:

<img width="361" alt="Screenshot 2022-06-23 at 12 00 21" src="https://user-images.githubusercontent.com/912770/175284407-894eeff7-da18-4d0e-9bfa-653018a136f8.png">

Tabbing over to "Date" will look like this (which can also be expanded and collapsed by pressing space while highlighted):

<img width="365" alt="Screenshot 2022-06-23 at 12 00 29" src="https://user-images.githubusercontent.com/912770/175284464-bc825252-6512-4343-9594-9c882d08cb2a.png">

### How to review

- In a separate shell, run the dp-design-system with `make debug`
- Run the frontend with `make debug`
- Verify that the Tab key now includes the accordion sections in its navigation

### Who can review

Front end / design system developers
