### PR TITLE
Correct calendar entry title size and spacing with associated content

### DIFF
--- a/assets/templates/partials/calendar/items/list.tmpl
+++ b/assets/templates/partials/calendar/items/list.tmpl
@@ -9,11 +9,11 @@
     <li class="ons-list__item ons-u-mt-l">
       <a
         href="{{ .URI }}"
-        class="ons-u-fs-l ons-u-td-no ons-u-d-b"
+        class="ons-u-fs-m ons-u-td-no ons-u-d-b"
       >
         {{- .Description.Title | safeHTML -}}
       </a>
-      <div class="ons-u-mt-s">
+      <div class="ons-u-mt-xs">
         <span class="ons-u-fs-r--b">{{ localise "ReleaseDate" $.Language 1 }}:</span>
         <span>{{ dateTimeOnsDatePatternFormat .Description.ReleaseDate $.Language }}</span>
         <span>|</span>


### PR DESCRIPTION
### What

Calendar entry title (link) text size is 22px, and spacing to content below is 9px (`ons-u-mt-xs`)

<img width="451" alt="Screenshot 2022-06-23 at 19 11 10" src="https://user-images.githubusercontent.com/912770/175366260-80929c60-8a5b-46e2-b561-cae8772f77a3.png">

### How to review

- In a separate shell, run dp-design-system with `make debug`
- Run this frontend with `make debug`
- Verify that calendar entry titles (links to releases) have the appropriate text size and spacing to the "Release date" below

### Who can review

Front end  / design system developers
