### PR TITLE
Add mobile-only dividing line between filters and sort by

### DIFF
--- a/assets/templates/calendar.tmpl
+++ b/assets/templates/calendar.tmpl
@@ -8,7 +8,7 @@
     </div>
 
     <!-- Right column -->
-    <div class="ons-grid__col ons-col-8@m ons-u-p-no@xxs@m">
+    <div class="ons-grid__col ons-col-8@m ons-u-pl-no@xxs@m ons-u-bt@xxs@m ons-u-pt-s@xxs@m">
       {{ template "partials/calendar/items" . }}
     </div>
   </div>


### PR DESCRIPTION
### What

A new dividing line is introduced between the last filter (Date) and the "Sort by" control that immediately follows it when on mobile.

<img width="376" alt="Screenshot 2022-06-24 at 14 36 37" src="https://user-images.githubusercontent.com/912770/175548608-5246afc0-d965-4edf-ad85-27ee2ff48aca.png">

### How to review

- In a separate shell, run the dp-design-system with `make debug`
- Run this frontend with `make debug`
- Verify that the new dividing line exists on mobile
- Verify that this same line is abset on the tablet and desktop views

### Who can review

Front end / design system developers
