### PR TITLE
Remove unnecessary id from hidden census input to avoid collision with filter census input

### DIFF
--- a/assets/templates/partials/calendar/hidden-inputs/census.tmpl
+++ b/assets/templates/partials/calendar/hidden-inputs/census.tmpl
@@ -1,14 +1,13 @@
 {{ range $type, $value := .ReleaseTypes }}
   {{ if eq $value.Name "census" }}
-    <input 
-      type="hidden" 
-      id="{{ $value.Id }}" 
-      name="{{ $value.Name}}" 
+    <input
+      type="hidden"
+      name="{{ $value.Name}}"
       {{ if $value.Checked }}
-        value="true" 
+        value="true"
         checked
       {{ else}}
-        value="" 
+        value=""
       {{ end }}>
   {{ end }}
 {{ end }}


### PR DESCRIPTION
### What

The Census filter label should toggle its associated checkbox input when clicked, but it doesn't.

Removing the duplicate id from the hidden census input avoids the collision that prevents the browser from correctly associating the label with the input.

### How to review

- In a separate shell, run dp-design-system with `make debug`
- Run this frontend with `make debug`
- View the calender http://localhost:27700/releasecalendar
- Verify that clicking on the Census label toggles its checkbox

### Who can review

Anyone
