### PR TITLE
Enable service message and emergency banner on calendar and releases

### DIFF
--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/releasecalendar"
 	search "github.com/ONSdigital/dp-api-clients-go/v2/site-search"
+	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 	"github.com/ONSdigital/dp-renderer/model"
 )
 
@@ -38,4 +39,9 @@ type SearchAPI interface {
 // BabbageClient is an interface to Babbage
 type BabbageAPI interface {
 	GetMaxAge(ctx context.Context, contentUri, key string) (int, error)
+}
+
+// ZebedeeClient is an interface for zebedee client
+type ZebedeeClient interface {
+	GetHomepageContent(ctx context.Context, userAccessToken, collectionID, lang, path string) (m zebedee.HomepageContent, err error)
 }

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -75,6 +75,7 @@ func TestUnitHandlers(t *testing.T) {
 		router := mux.NewRouter()
 
 		Convey("test Release endpoints", func() {
+			mockZebedeeClient := NewMockZebedeeClient(mockCtrl)
 			mockApiClient := NewMockReleaseCalendarAPI(mockCtrl)
 			root := "/releases"
 			maxAge := 670
@@ -87,13 +88,14 @@ func TestUnitHandlers(t *testing.T) {
 			r.URI = fmt.Sprintf("%s/%s", root, titleSegment)
 
 			Convey("test '/releases'", func() {
-				router.HandleFunc(root+"/{release-title}", Release(*mockConfig, mockRenderClient, mockApiClient, mockBabbageAPI))
+				router.HandleFunc(root+"/{release-title}", Release(*mockConfig, mockRenderClient, mockApiClient, mockBabbageAPI, mockZebedeeClient))
 
 				req := httptest.NewRequest("GET", fmt.Sprintf("http://localhost:27700%s/%s", root, titleSegment), nil)
 				Convey("When there is an error getting the release from the release calendar API", func() {
 					apiError := errors.New("error reading data")
 					Convey("And the request uses headers", func() {
 						setRequestHeaders(req)
+						mockZebedeeClient.EXPECT().GetHomepageContent(ctx, accessToken, collectionID, lang, "/")
 						mockApiClient.EXPECT().GetLegacyRelease(ctx, accessToken, collectionID, lang, r.URI).Return(nil, apiError)
 
 						Convey("Then it returns 500", func() {
@@ -104,6 +106,7 @@ func TestUnitHandlers(t *testing.T) {
 					})
 
 					Convey("And the request does not use headers", func() {
+						mockZebedeeClient.EXPECT().GetHomepageContent(ctx, "", "", lang, "/")
 						mockApiClient.EXPECT().GetLegacyRelease(ctx, "", "", lang, r.URI).Return(&r, nil).Return(nil, apiError)
 
 						Convey("Then it returns 500", func() {
@@ -120,6 +123,7 @@ func TestUnitHandlers(t *testing.T) {
 
 					Convey("And the request uses headers", func() {
 						setRequestHeaders(req)
+						mockZebedeeClient.EXPECT().GetHomepageContent(ctx, accessToken, collectionID, lang, "/")
 						mockApiClient.EXPECT().GetLegacyRelease(ctx, accessToken, collectionID, lang, r.URI).Return(&r, nil)
 
 						Convey("And Babbage calculates the cache max age successfully", func() {
@@ -147,6 +151,7 @@ func TestUnitHandlers(t *testing.T) {
 					})
 
 					Convey("And the request does not use headers", func() {
+						mockZebedeeClient.EXPECT().GetHomepageContent(ctx, "", "", lang, "/")
 						mockApiClient.EXPECT().GetLegacyRelease(ctx, "", "", lang, r.URI).Return(&r, nil)
 
 						Convey("And Babbage calculates the cache max age successfully", func() {
@@ -226,11 +231,12 @@ func TestUnitHandlers(t *testing.T) {
 
 		Convey("test ReleaseCalendar endpoints", func() {
 			mockSearchClient := NewMockSearchAPI(mockCtrl)
+			mockZebedeeClient := NewMockZebedeeClient(mockCtrl)
 
 			Convey("test '/releasecalendar' endpoint", func() {
 				endpoint := "/releasecalendar"
 				maxAge := 422
-				router.HandleFunc(endpoint, ReleaseCalendar(*mockConfig, mockRenderClient, mockSearchClient, mockBabbageAPI))
+				router.HandleFunc(endpoint, ReleaseCalendar(*mockConfig, mockRenderClient, mockSearchClient, mockBabbageAPI, mockZebedeeClient))
 				r := sitesearch.ReleaseResponse{
 					Releases: []sitesearch.Release{
 						{
@@ -248,6 +254,7 @@ func TestUnitHandlers(t *testing.T) {
 
 						Convey("And the request uses headers", func() {
 							setRequestHeaders(req)
+							mockZebedeeClient.EXPECT().GetHomepageContent(ctx, accessToken, collectionID, lang, "/")
 							mockSearchClient.EXPECT().GetReleases(ctx, accessToken, collectionID, lang, defaultParams()).Return(r, apiError)
 
 							Convey("Then it returns 500", func() {
@@ -258,6 +265,7 @@ func TestUnitHandlers(t *testing.T) {
 						})
 
 						Convey("And the request does not use headers", func() {
+							mockZebedeeClient.EXPECT().GetHomepageContent(ctx, "", "", lang, "/")
 							mockSearchClient.EXPECT().GetReleases(ctx, "", "", lang, defaultParams()).Return(r, apiError)
 
 							Convey("Then it returns 500", func() {
@@ -274,6 +282,7 @@ func TestUnitHandlers(t *testing.T) {
 
 						Convey("And the request uses headers", func() {
 							setRequestHeaders(req)
+							mockZebedeeClient.EXPECT().GetHomepageContent(ctx, accessToken, collectionID, lang, "/")
 							mockSearchClient.EXPECT().GetReleases(ctx, accessToken, collectionID, lang, defaultParams()).Return(r, nil)
 
 							Convey("And Babbage calculates the cache max age successfully", func() {
@@ -301,6 +310,7 @@ func TestUnitHandlers(t *testing.T) {
 						})
 
 						Convey("And the request does not use headers", func() {
+							mockZebedeeClient.EXPECT().GetHomepageContent(ctx, "", "", lang, "/")
 							mockSearchClient.EXPECT().GetReleases(ctx, "", "", lang, defaultParams()).Return(r, nil)
 
 							Convey("And Babbage calculates the cache max age successfully", func() {

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -12,6 +12,7 @@ import (
 
 	releasecalendar "github.com/ONSdigital/dp-api-clients-go/v2/releasecalendar"
 	search "github.com/ONSdigital/dp-api-clients-go/v2/site-search"
+	zebedee "github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 	model "github.com/ONSdigital/dp-renderer/model"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -228,4 +229,42 @@ func (m *MockBabbageAPI) GetMaxAge(ctx context.Context, contentUri, key string) 
 func (mr *MockBabbageAPIMockRecorder) GetMaxAge(ctx, contentUri, key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxAge", reflect.TypeOf((*MockBabbageAPI)(nil).GetMaxAge), ctx, contentUri, key)
+}
+
+// MockZebedeeClient is a mock of ZebedeeClient interface.
+type MockZebedeeClient struct {
+	ctrl     *gomock.Controller
+	recorder *MockZebedeeClientMockRecorder
+}
+
+// MockZebedeeClientMockRecorder is the mock recorder for MockZebedeeClient.
+type MockZebedeeClientMockRecorder struct {
+	mock *MockZebedeeClient
+}
+
+// NewMockZebedeeClient creates a new mock instance.
+func NewMockZebedeeClient(ctrl *gomock.Controller) *MockZebedeeClient {
+	mock := &MockZebedeeClient{ctrl: ctrl}
+	mock.recorder = &MockZebedeeClientMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockZebedeeClient) EXPECT() *MockZebedeeClientMockRecorder {
+	return m.recorder
+}
+
+// GetHomepageContent mocks base method.
+func (m *MockZebedeeClient) GetHomepageContent(ctx context.Context, userAccessToken, collectionID, lang, path string) (zebedee.HomepageContent, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHomepageContent", ctx, userAccessToken, collectionID, lang, path)
+	ret0, _ := ret[0].(zebedee.HomepageContent)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHomepageContent indicates an expected call of GetHomepageContent.
+func (mr *MockZebedeeClientMockRecorder) GetHomepageContent(ctx, userAccessToken, collectionID, lang, path interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHomepageContent", reflect.TypeOf((*MockZebedeeClient)(nil).GetHomepageContent), ctx, userAccessToken, collectionID, lang, path)
 }

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -3,9 +3,11 @@ package mapper
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/releasecalendar"
 	search "github.com/ONSdigital/dp-api-clients-go/v2/site-search"
+	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 	"github.com/ONSdigital/dp-frontend-release-calendar/config"
 	"github.com/ONSdigital/dp-frontend-release-calendar/model"
 	"github.com/ONSdigital/dp-frontend-release-calendar/queryparams"
@@ -118,7 +120,20 @@ func createTableOfContents(
 	return toc
 }
 
-func CreateRelease(basePage coreModel.Page, release releasecalendar.Release, lang, path string) model.Release {
+func mapEmergencyBanner(bannerData zebedee.EmergencyBanner) coreModel.EmergencyBanner {
+	var mappedEmergencyBanner coreModel.EmergencyBanner
+	emptyBannerObj := zebedee.EmergencyBanner{}
+	if bannerData != emptyBannerObj {
+		mappedEmergencyBanner.Title = bannerData.Title
+		mappedEmergencyBanner.Type = strings.Replace(bannerData.Type, "_", "-", -1)
+		mappedEmergencyBanner.Description = bannerData.Description
+		mappedEmergencyBanner.URI = bannerData.URI
+		mappedEmergencyBanner.LinkText = bannerData.LinkText
+	}
+	return mappedEmergencyBanner
+}
+
+func CreateRelease(basePage coreModel.Page, release releasecalendar.Release, lang, path, serviceMessage string, emergencyBannerContent zebedee.EmergencyBanner) model.Release {
 	result := model.Release{
 		Page:     basePage,
 		Markdown: release.Markdown,
@@ -143,6 +158,8 @@ func CreateRelease(basePage coreModel.Page, release releasecalendar.Release, lan
 		},
 	}
 	result.Language = lang
+	result.ServiceMessage = serviceMessage
+	result.EmergencyBanner = mapEmergencyBanner(emergencyBannerContent)
 	result.RelatedDatasets = mapLink(release.RelatedDatasets)
 	result.RelatedDocuments = mapLink(release.RelatedDocuments)
 	result.RelatedMethodology = mapLink(release.RelatedMethodology)
@@ -220,12 +237,14 @@ func mapLink(links []releasecalendar.Link) []model.Link {
 	return res
 }
 
-func CreateReleaseCalendar(basePage coreModel.Page, params queryparams.ValidatedParams, response search.ReleaseResponse, cfg config.Config, lang string) model.Calendar {
+func CreateReleaseCalendar(basePage coreModel.Page, params queryparams.ValidatedParams, response search.ReleaseResponse, cfg config.Config, lang, serviceMessage string, emergencyBannerContent zebedee.EmergencyBanner) model.Calendar {
 	calendar := model.Calendar{
 		Page: basePage,
 	}
 	calendar.Language = lang
 	calendar.BetaBannerEnabled = true
+	calendar.ServiceMessage = serviceMessage
+	calendar.EmergencyBanner = mapEmergencyBanner(emergencyBannerContent)
 	calendar.Metadata.Title = helper.Localise("ReleaseCalendarPageTitle", calendar.Language, 1)
 	calendar.KeywordSearch = coreModel.CompactSearch{
 		ElementId: "keyword-search",

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/releasecalendar"
 	sitesearch "github.com/ONSdigital/dp-api-clients-go/v2/site-search"
+	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 	"github.com/ONSdigital/dp-frontend-release-calendar/config"
 	"github.com/ONSdigital/dp-frontend-release-calendar/mocks"
 	"github.com/ONSdigital/dp-frontend-release-calendar/model"
@@ -119,11 +120,30 @@ func TestUnitMapper(t *testing.T) {
 			crumbLabelHome := "Hafan"
 			crumbLabelReleaseCalendar := "Calendr datganiadau"
 			crumbLabelCancelled := "Canslwyd"
-			release := CreateRelease(basePage, releaseResponse, lang, "/prefix/releasecalendar")
+			serviceMessage := "Service Message"
+			emergencyBannerTitle := "Emergency Title"
+			emergencyBannerType := "notable-death"
+			emergencyBannerDescription := "Emergency Description"
+			emergencyBannerUri := "https://example.com/emergency"
+			emergencyBannerLinkText := "Attention, this is an emergency. There's an emergency going on."
+			bannerData := zebedee.EmergencyBanner{
+				Title:       emergencyBannerTitle,
+				Type:        emergencyBannerType,
+				Description: emergencyBannerDescription,
+				URI:         emergencyBannerUri,
+				LinkText:    emergencyBannerLinkText,
+			}
+			release := CreateRelease(basePage, releaseResponse, lang, "/prefix/releasecalendar", serviceMessage, bannerData)
 
 			So(release.PatternLibraryAssetsPath, ShouldEqual, basePage.PatternLibraryAssetsPath)
 			So(release.SiteDomain, ShouldEqual, basePage.SiteDomain)
 			So(release.BetaBannerEnabled, ShouldBeTrue)
+			So(release.ServiceMessage, ShouldEqual, serviceMessage)
+			So(release.EmergencyBanner.Title, ShouldEqual, emergencyBannerTitle)
+			So(release.EmergencyBanner.Type, ShouldEqual, emergencyBannerType)
+			So(release.EmergencyBanner.Description, ShouldEqual, emergencyBannerDescription)
+			So(release.EmergencyBanner.URI, ShouldEqual, emergencyBannerUri)
+			So(release.EmergencyBanner.LinkText, ShouldEqual, emergencyBannerLinkText)
 			So(release.Metadata.Title, ShouldEqual, releaseResponse.Description.Title)
 			So(release.URI, ShouldEqual, releaseResponse.URI)
 			So(release.Markdown, ShouldResemble, releaseResponse.Markdown)
@@ -262,11 +282,31 @@ func TestReleaseCalendarMapper(t *testing.T) {
 		Convey("CreateReleaseCalendar maps correctly to a model Calendar object", func() {
 			lang := "cy"
 			metaTitle := "Calendr datganiadau"
-			calendar := CreateReleaseCalendar(basePage, params, releaseResponse, cfg, lang)
+			serviceMessage := "Service Message"
+			emergencyBannerTitle := "Emergency Title"
+			emergencyBannerType := "notable-death"
+			emergencyBannerDescription := "Emergency Description"
+			emergencyBannerUri := "https://example.com/emergency"
+			emergencyBannerLinkText := "Attention, this is an emergency. There's an emergency going on."
+			bannerData := zebedee.EmergencyBanner{
+				Title:       emergencyBannerTitle,
+				Type:        emergencyBannerType,
+				Description: emergencyBannerDescription,
+				URI:         emergencyBannerUri,
+				LinkText:    emergencyBannerLinkText,
+			}
+
+			calendar := CreateReleaseCalendar(basePage, params, releaseResponse, cfg, lang, serviceMessage, bannerData)
 
 			So(calendar.PatternLibraryAssetsPath, ShouldEqual, basePage.PatternLibraryAssetsPath)
 			So(calendar.SiteDomain, ShouldEqual, basePage.SiteDomain)
 			So(calendar.BetaBannerEnabled, ShouldBeTrue)
+			So(calendar.ServiceMessage, ShouldEqual, serviceMessage)
+			So(calendar.EmergencyBanner.Title, ShouldEqual, emergencyBannerTitle)
+			So(calendar.EmergencyBanner.Type, ShouldEqual, emergencyBannerType)
+			So(calendar.EmergencyBanner.Description, ShouldEqual, emergencyBannerDescription)
+			So(calendar.EmergencyBanner.URI, ShouldEqual, emergencyBannerUri)
+			So(calendar.EmergencyBanner.LinkText, ShouldEqual, emergencyBannerLinkText)
 			So(calendar.Metadata.Title, ShouldEqual, metaTitle)
 			So(calendar.KeywordSearch.SearchTerm, ShouldEqual, params.Keywords)
 			So(calendar.Sort, ShouldResemble, model.Sort{Mode: params.Sort.String(), Options: mapSortOptions(params)})

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/releasecalendar"
 	search "github.com/ONSdigital/dp-api-clients-go/v2/site-search"
+	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 	"github.com/ONSdigital/dp-frontend-release-calendar/config"
 	"github.com/ONSdigital/dp-frontend-release-calendar/handlers"
 
@@ -22,6 +23,7 @@ type Clients struct {
 	ReleaseCalendarAPI *releasecalendar.Client
 	SearchAPI          *search.Client
 	BabbageAPI         *handlers.BabbageClient
+	ZebedeeClient      *zebedee.Client
 }
 
 // Setup registers routes for the service
@@ -29,9 +31,9 @@ func Setup(ctx context.Context, r *mux.Router, cfg *config.Config, c Clients) {
 	log.Info(ctx, "adding routes")
 	r.StrictSlash(true).Path("/health").HandlerFunc(c.HealthCheckHandler)
 
-	r.StrictSlash(true).Path(cfg.RoutingPrefix + "/releases/{uri}").Methods("GET").HandlerFunc(handlers.Release(*cfg, c.Render, c.ReleaseCalendarAPI, c.BabbageAPI))
+	r.StrictSlash(true).Path(cfg.RoutingPrefix + "/releases/{uri}").Methods("GET").HandlerFunc(handlers.Release(*cfg, c.Render, c.ReleaseCalendarAPI, c.BabbageAPI, c.ZebedeeClient))
 	r.StrictSlash(true).Path(cfg.RoutingPrefix + "/releases/{uri}/data").Methods("GET").HandlerFunc(handlers.ReleaseData(*cfg, c.ReleaseCalendarAPI))
-	r.StrictSlash(true).Path(cfg.RoutingPrefix + "/releasecalendar").Methods("GET").HandlerFunc(handlers.ReleaseCalendar(*cfg, c.Render, c.SearchAPI, c.BabbageAPI))
+	r.StrictSlash(true).Path(cfg.RoutingPrefix + "/releasecalendar").Methods("GET").HandlerFunc(handlers.ReleaseCalendar(*cfg, c.Render, c.SearchAPI, c.BabbageAPI, c.ZebedeeClient))
 	r.StrictSlash(true).Path(cfg.RoutingPrefix + "/releasecalendar/data").Methods("GET").HandlerFunc(handlers.ReleaseCalendarData(*cfg, c.SearchAPI))
 	r.StrictSlash(true).Path(cfg.RoutingPrefix + "/calendar/releasecalendar").Methods("GET").HandlerFunc(handlers.ReleaseCalendarICSEntries(*cfg, c.SearchAPI))
 }

--- a/service/service.go
+++ b/service/service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/releasecalendar"
 	sitesearch "github.com/ONSdigital/dp-api-clients-go/v2/site-search"
+	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 	"github.com/ONSdigital/dp-frontend-release-calendar/assets"
 	"github.com/ONSdigital/dp-frontend-release-calendar/config"
 	"github.com/ONSdigital/dp-frontend-release-calendar/handlers"
@@ -53,6 +54,7 @@ func (svc *Service) Init(ctx context.Context, cfg *config.Config, serviceList *E
 		ReleaseCalendarAPI: releasecalendar.NewWithHealthClient(routerHealthClient),
 		SearchAPI:          sitesearch.NewWithHealthClient(routerHealthClient),
 		BabbageAPI:         handlers.NewBabbageClient(cfg.BabbageURL),
+		ZebedeeClient:      zebedee.NewWithHealthClient(routerHealthClient),
 	}
 
 	// Get healthcheck with checkers


### PR DESCRIPTION
### What

Echoes the service message and/or emergency banner when set on the homepage via Florence.

Release Calendar

<img width="1120" alt="Screenshot 2022-09-13 at 14 56 07" src="https://user-images.githubusercontent.com/912770/189929929-349f2ea3-c786-4b5d-b186-dbf7e0b779bd.png">

Release Page

<img width="1135" alt="Screenshot 2022-09-13 at 14 55 54" src="https://user-images.githubusercontent.com/912770/189929983-0aa1985c-99dc-4662-9da0-f147b8c2ecc8.png">

### How to review

- In a separate shell, run dp-design-system with `make debug`
- Run this frontend with `make debug`
- Verify that the Release Calendar and Release pages display the service message and/or emergency banner when set by Florence in your environment

### Who can review

Go / Frontend developers
