### PR TITLE
Fix issue with sort order of results when sorting by date.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -64,7 +64,7 @@ func get() (*Config, error) {
 		Debug:                       false,
 		DefaultLimit:                10,
 		DefaultMaximumLimit:         100,
-		DefaultSort:                 queryparams.RelDateDesc.String(),
+		DefaultSort:                 queryparams.Newest,
 		DefaultMaximumSearchResults: 1000,
 		GracefulShutdownTimeout:     5 * time.Second,
 		HealthCheckInterval:         30 * time.Second,

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -189,7 +189,14 @@ func validateParams(ctx context.Context, params url.Values, cfg config.Config) (
 	params.Set(queryparams.DateTo, toDate.String())
 	validatedParams.BeforeDate = toDate
 
-	sort, err := queryparams.GetSortOrder(ctx, params, queryparams.MustParseSort(cfg.DefaultSort))
+	releaseType, err := queryparams.GetReleaseType(ctx, params, queryparams.Published)
+	if err != nil {
+		return validatedParams, err
+	}
+	params.Set(queryparams.Type, releaseType.String())
+	validatedParams.ReleaseType = releaseType
+
+	sort, err := queryparams.GetSortOrder(ctx, params, releaseType, queryparams.MustParseSort(cfg.DefaultSort))
 	if err != nil {
 		return validatedParams, err
 	}
@@ -203,13 +210,6 @@ func validateParams(ctx context.Context, params url.Values, cfg config.Config) (
 	params.Set(queryparams.Keywords, keywords)
 	validatedParams.Keywords = keywords
 	params.Set(queryparams.Query, keywords)
-
-	releaseType, err := queryparams.GetReleaseType(ctx, params, queryparams.Published)
-	if err != nil {
-		return validatedParams, err
-	}
-	params.Set(queryparams.Type, releaseType.String())
-	validatedParams.ReleaseType = releaseType
 
 	provisional, set, err := queryparams.GetBoolean(ctx, params, queryparams.Provisional.String(), false)
 	validatedParams.Provisional = provisional
@@ -253,7 +253,7 @@ func releaseCalendarICSEntries(w http.ResponseWriter, req *http.Request, userAcc
 	params := req.URL.Query()
 
 	params.Set(queryparams.Limit, strconv.Itoa(cfg.DefaultMaximumSearchResults))
-	params.Set(queryparams.SortName, queryparams.RelDateAsc.BackendString())
+	params.Set(queryparams.SortName, queryparams.RelDateAsc)
 	params.Set(queryparams.DateTo, time.Now().AddDate(0, 3, 0).Format(queryparams.DateFormat))
 	params.Set(queryparams.Type, queryparams.Upcoming.String())
 

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -139,7 +139,7 @@ func TestUnitHandlers(t *testing.T) {
 						})
 
 						Convey("And there is an error calling Babbage", func() {
-							mockBabbageAPI.EXPECT().GetMaxAge(ctx, r.URI, mockConfig.MaxAgeKey).Return(maxAge, errors.New("Error on Babbage"))
+							mockBabbageAPI.EXPECT().GetMaxAge(ctx, r.URI, mockConfig.MaxAgeKey).Return(maxAge, errors.New("error on Babbage"))
 
 							Convey("Then it returns 200 and the default cache header", func() {
 								router.ServeHTTP(w, req)
@@ -166,7 +166,7 @@ func TestUnitHandlers(t *testing.T) {
 						})
 
 						Convey("And there is an error calling Babbage", func() {
-							mockBabbageAPI.EXPECT().GetMaxAge(ctx, r.URI, mockConfig.MaxAgeKey).Return(maxAge, errors.New("Error on Babbage"))
+							mockBabbageAPI.EXPECT().GetMaxAge(ctx, r.URI, mockConfig.MaxAgeKey).Return(maxAge, errors.New("error on Babbage"))
 
 							Convey("Then it returns 200 and the default cache header", func() {
 								router.ServeHTTP(w, req)
@@ -298,7 +298,7 @@ func TestUnitHandlers(t *testing.T) {
 							})
 
 							Convey("And there is an error calling Babbage", func() {
-								mockBabbageAPI.EXPECT().GetMaxAge(ctx, "/releasecalendar", mockConfig.MaxAgeKey).Return(maxAge, errors.New("Error on Babbage"))
+								mockBabbageAPI.EXPECT().GetMaxAge(ctx, "/releasecalendar", mockConfig.MaxAgeKey).Return(maxAge, errors.New("error on Babbage"))
 
 								Convey("Then it returns 200 and the default cache header", func() {
 									router.ServeHTTP(w, req)
@@ -326,7 +326,7 @@ func TestUnitHandlers(t *testing.T) {
 							})
 
 							Convey("And there is an error calling Babbage", func() {
-								mockBabbageAPI.EXPECT().GetMaxAge(ctx, "/releasecalendar", mockConfig.MaxAgeKey).Return(maxAge, errors.New("Error on Babbage"))
+								mockBabbageAPI.EXPECT().GetMaxAge(ctx, "/releasecalendar", mockConfig.MaxAgeKey).Return(maxAge, errors.New("error on Babbage"))
 
 								Convey("Then it returns 200 and the default cache header", func() {
 									router.ServeHTTP(w, req)
@@ -531,7 +531,7 @@ func defaultParams() url.Values {
 	values.Set("offset", "0")
 	values.Set("fromDate", "")
 	values.Set("toDate", "")
-	values.Set("sort", queryparams.RelDateDesc.BackendString())
+	values.Set("sort", queryparams.RelDateDesc)
 	values.Set("keywords", "")
 	values.Set("query", "")
 	values.Set("release-type", queryparams.Published.Name())
@@ -544,7 +544,7 @@ func defaultICSParams() url.Values {
 	values := url.Values{}
 	values.Set("limit", "1000")
 	values.Set("toDate", time.Now().AddDate(0, 3, 0).Format(queryparams.DateFormat))
-	values.Set("sort", queryparams.RelDateAsc.BackendString())
+	values.Set("sort", queryparams.RelDateAsc)
 	values.Set("release-type", queryparams.Upcoming.String())
 
 	return values

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -502,31 +502,31 @@ func mapSortOptions(params queryparams.ValidatedParams) []model.SortOption {
 		{
 			LocaleKey: "ReleaseCalendarSortOptionDateNewest",
 			Plural:    1,
-			Value:     queryparams.RelDateDesc.String(),
+			Value:     queryparams.Newest,
 			Disabled:  false,
 		},
 		{
 			LocaleKey: "ReleaseCalendarSortOptionDateOldest",
 			Plural:    1,
-			Value:     queryparams.RelDateAsc.String(),
+			Value:     queryparams.Oldest,
 			Disabled:  false,
 		},
 		{
 			LocaleKey: "ReleaseCalendarSortOptionAlphabeticalAZ",
 			Plural:    1,
-			Value:     queryparams.TitleAZ.String(),
+			Value:     queryparams.AlphaUser,
 			Disabled:  false,
 		},
 		{
 			LocaleKey: "ReleaseCalendarSortOptionAlphabeticalZA",
 			Plural:    1,
-			Value:     queryparams.TitleZA.String(),
+			Value:     queryparams.ReverseAlphaUser,
 			Disabled:  false,
 		},
 		{
 			LocaleKey: "ReleaseCalendarSortOptionRelevance",
 			Plural:    1,
-			Value:     queryparams.Relevance.String(),
+			Value:     queryparams.RelevanceLabel,
 			Disabled: func(keywords string) bool {
 				if keywords == "" {
 					return true

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -273,7 +273,7 @@ func TestReleaseCalendarMapper(t *testing.T) {
 			AfterDate:   queryparams.Date{},
 			BeforeDate:  queryparams.Date{},
 			Keywords:    "everything",
-			Sort:        queryparams.RelDateAsc,
+			Sort:        queryparams.MustParseSort(queryparams.Newest),
 			ReleaseType: queryparams.Upcoming,
 		}
 
@@ -483,7 +483,7 @@ func TestGetPageURL(t *testing.T) {
 					Page:        2,
 					AfterDate:   queryparams.MustParseDate("2021-11-30"),
 					Keywords:    "test",
-					Sort:        queryparams.TitleAZ,
+					Sort:        queryparams.MustParseSort(queryparams.AlphaUser),
 					ReleaseType: queryparams.Published,
 					Highlight:   true,
 				},
@@ -495,7 +495,7 @@ func TestGetPageURL(t *testing.T) {
 					Limit:       25,
 					Page:        5,
 					BeforeDate:  queryparams.MustParseDate("2022-04-01"),
-					Sort:        queryparams.RelDateDesc,
+					Sort:        queryparams.MustParseSort(queryparams.Newest),
 					ReleaseType: queryparams.Upcoming,
 					Provisional: true,
 					Postponed:   true,


### PR DESCRIPTION
### What

Change the meaning 'Newest' at the frontend for Upcoming releases to mean the first in the list is the next one in the future, not the furthest one in the future.

'Newest' at the frontend is now defined as 'the closest date to today', and is teh default for all release-types (Published, Upcoming and Cancelled) . Its meaning in terms of algorithmic definition (ascending/descending) is therfore reversed depending on the release-type that is being viewed, i.e. Published/Cancelled or Upcoming.

### How to review

Review code and ensure tests pass

### Who can review

Anyone
