### PR TITLE
Simplify parameter validation

### DIFF
--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -529,14 +529,9 @@ func defaultParams() url.Values {
 	values.Set("limit", "10")
 	values.Set("page", "1")
 	values.Set("offset", "0")
-	values.Set("fromDate", "")
-	values.Set("toDate", "")
 	values.Set("sort", queryparams.RelDateDesc.BackendString())
-	values.Set("keywords", "")
-	values.Set("query", "")
 	values.Set("release-type", queryparams.Published.Name())
 	values.Set("highlight", "true")
-
 	return values
 }
 

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -385,7 +385,7 @@ func getWindowStartEndPage(currentPage, totalPages, windowSize int) (int, int) {
 }
 
 func getPageURL(page int, params queryparams.ValidatedParams, path string) (pageURL string) {
-	query := params.AsQuery()
+	query := params.AsFrontendQuery()
 	query.Set("page", strconv.Itoa(page))
 
 	return path + "?" + query.Encode()

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -488,7 +488,7 @@ func TestGetPageURL(t *testing.T) {
 					Highlight:   true,
 				},
 				path:     "/test-prefix/releasecalendar",
-				expected: "/test-prefix/releasecalendar?after-day=30&after-month=11&after-year=2021&before-day=&before-month=&before-year=&census=false&highlight=true&keywords=test&limit=10&page=2&release-type=type-published&sort=alphabetical-az",
+				expected: "/test-prefix/releasecalendar?after-day=30&after-month=11&after-year=2021&highlight=true&keywords=test&limit=10&page=2&release-type=type-published&sort=alphabetical-az",
 			},
 			{
 				params: queryparams.ValidatedParams{
@@ -502,7 +502,7 @@ func TestGetPageURL(t *testing.T) {
 					Census:      true,
 				},
 				path:     "/releasecalendar",
-				expected: "/releasecalendar?after-day=&after-month=&after-year=&before-day=1&before-month=4&before-year=2022&census=true&highlight=false&keywords=&limit=25&page=5&release-type=type-upcoming&sort=date-newest&subtype-confirmed=false&subtype-postponed=true&subtype-provisional=true",
+				expected: "/releasecalendar?before-day=1&before-month=4&before-year=2022&census=true&limit=25&page=5&release-type=type-upcoming&sort=date-newest&subtype-postponed=true&subtype-provisional=true",
 			},
 		}
 


### PR DESCRIPTION
### What
Use `validatedParams` to create the query to be sent to the api instead of working with the current one (adding and amending parameters)
This ensure validation has taken place and simplify the code
It also fixes a bug where the data endpoint is not filtering results correctly and will reduce the number of parameters in the url as empty ones won't be added.

### How to review

Check code changes make sense and tests pass
Check the filtering and paging still work correctly

### Who can review

Anyone but probably @PatrickConnollyONS is the one with the most knowledge of this piece of code
