### PR TITLE
Error landing page

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -16,6 +16,10 @@
 description = "Release Calendar Title"
 one = "Calendr datganiadau"
 
+[ReleaseCalendarErrorTitleValidation]
+description = "A filter could not be validated, please go back and amend it"
+one = "A filter could not be validated, please go back and amend it (cy)"
+
 [ReleaseCalendarPageSearchKeywords]
 description = "Release Calendar Page Search Keywords"
 one = "Chwilio am eiriau allweddol"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -16,6 +16,10 @@
 description = "Release Calendar Title"
 one = "Release calendar"
 
+[ReleaseCalendarErrorTitleValidation]
+description = "A filter could not be validated, please go back and amend it"
+one = "A filter could not be validated, please go back and amend it"
+
 [ReleaseCalendarPageSearchKeywords]
 description = "Release Calendar Page Search Keywords"
 one = "Search keywords"

--- a/assets/templates/calendar.tmpl
+++ b/assets/templates/calendar.tmpl
@@ -1,15 +1,19 @@
 <div class="ons-page__container ons-container release-calendar">
   <div class="ons-grid ons-u-ml-no">
     <h1 class="ons-u-fs-xxxl ons-u-mt-m ons-u-mb-xl">{{ localise "ReleaseCalendarPageTitle" .Language 1 }}</h1>
-
-    {{/* Left column */}}
-    <div class="ons-grid__col ons-col-4@m ons-u-p-no">
-      {{ template "partials/calendar/filters" . }}
-    </div>
-
-    {{/* Right column */}}
-    <div class="ons-grid__col ons-col-8@m ons-u-pl-no@xxs@m ons-u-bt@xxs@m ons-u-pt-s@xxs@m">
-      {{ template "partials/calendar/items" . }}
-    </div>
+    {{ if and .GlobalError.Title.LocaleKey .GlobalError.Message }}
+      <div class="ons-grid__col ons-col-12@m ons-u-p-no ons-u-mb-xl">
+        {{ template "partials/calendar/global-error" . }}
+      </div>
+    {{ else }}
+      {{/* Left column */}}
+      <div class="ons-grid__col ons-col-4@m ons-u-p-no">
+        {{ template "partials/calendar/filters" . }}
+      </div>
+      {{/* Right column */}}
+      <div class="ons-grid__col ons-col-8@m ons-u-pl-no@xxs@m ons-u-bt@xxs@m ons-u-pt-s@xxs@m">
+        {{ template "partials/calendar/items" . }}
+      </div>
+    {{ end }}
   </div>
 </div>

--- a/assets/templates/partials/calendar/global-error.tmpl
+++ b/assets/templates/partials/calendar/global-error.tmpl
@@ -1,0 +1,19 @@
+<div
+  aria-labelledby="alert"
+  role="alert"
+  tabindex="-1"
+  class="ons-panel ons-panel--error"
+>
+  <div class="ons-panel__header">
+    <h2
+      id="alert"
+      data-qa="error-header"
+      class="ons-panel__title ons-u-fs-r--b"
+    >
+      {{- localise .GlobalError.Title.LocaleKey .Language .GlobalError.Title.Plural -}}
+    </h2>
+  </div>
+  <div class="ons-panel__body">
+    <p>{{ .GlobalError.Message | safeHTML }}</p>
+  </div>
+</div>

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -106,6 +106,8 @@ func ReleaseCalendar(cfg config.Config, rc RenderClient, api SearchAPI, babbage 
 		validatedParams, err := validateParams(ctx, params, cfg)
 		if err != nil {
 			setStatusCode(r, w, err)
+			calendar := mapper.CreateReleaseCalendarError(rc.NewBasePageModel(), lang, "ReleaseCalendarErrorTitleValidation", err)
+			rc.BuildPage(w, calendar, "calendar")
 			return
 		}
 
@@ -120,11 +122,8 @@ func ReleaseCalendar(cfg config.Config, rc RenderClient, api SearchAPI, babbage 
 			return
 		}
 
-		basePage := rc.NewBasePageModel()
-		calendar := mapper.CreateReleaseCalendar(basePage, validatedParams, releases, cfg, lang, homepageContent.ServiceMessage, homepageContent.EmergencyBanner)
-
+		calendar := mapper.CreateReleaseCalendar(rc.NewBasePageModel(), validatedParams, releases, cfg, lang, homepageContent.ServiceMessage, homepageContent.EmergencyBanner)
 		setCacheHeader(ctx, w, babbage, "/releasecalendar", cfg.MaxAgeKey)
-
 		rc.BuildPage(w, calendar, "calendar")
 	})
 }

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -341,6 +341,8 @@ func TestUnitHandlers(t *testing.T) {
 
 				Convey("Given a request with parameters", func() {
 					Convey("When the limit parameter is negative", func() {
+						mockRenderClient.EXPECT().NewBasePageModel()
+						mockRenderClient.EXPECT().BuildPage(w, gomock.Any(), "calendar")
 						req := httptest.NewRequest("GET", fmt.Sprintf("http://localhost:27700%s?limit=-1", endpoint), nil)
 
 						Convey("Then it returns 500", func() {

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -313,6 +313,23 @@ func CreateReleaseCalendar(basePage coreModel.Page, params queryparams.Validated
 	return calendar
 }
 
+func CreateReleaseCalendarError(basePage coreModel.Page, lang, errorTitleKey string, globalError error) model.Calendar {
+	calendar := model.Calendar{
+		Page: basePage,
+	}
+	calendar.Language = lang
+	calendar.BetaBannerEnabled = true
+	calendar.Metadata.Title = helper.Localise("ReleaseCalendarPageTitle", calendar.Language, 1)
+	calendar.GlobalError = model.GlobalError{
+		Title: coreModel.Localisation{
+			LocaleKey: errorTitleKey,
+			Plural:    1,
+		},
+		Message: globalError.Error(),
+	}
+	return calendar
+}
+
 // The current page number sits within a window, and the window size determines the
 // number of pages around the current page. For example a window size of 3 with the
 // current page shown in () would give:

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -1,6 +1,7 @@
 package mapper
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -387,6 +388,29 @@ func TestReleaseCalendarMapper(t *testing.T) {
 			for i, r := range calendar.Entries {
 				So(r.PublicationState, ShouldResemble, expectedStates[i])
 			}
+		})
+	})
+}
+
+func TestReleaseCalendarErrorMapper(t *testing.T) {
+	helper.InitialiseLocalisationsHelper(mocks.MockAssetFunction)
+	Convey("Given a Release Calendar and a base page", t, func() {
+		basePage := coreModel.NewPage("path/to/assets", "site-domain")
+
+		Convey("CreateReleaseCalendarError maps correctly to a model Calendar object", func() {
+			lang := "cy"
+			metaTitle := "Calendr datganiadau"
+			err := errors.New("test error message")
+			errTitleKey := "ReleaseCalendarErrorTitleValidation"
+
+			calendar := CreateReleaseCalendarError(basePage, lang, errTitleKey, err)
+
+			So(calendar.PatternLibraryAssetsPath, ShouldEqual, basePage.PatternLibraryAssetsPath)
+			So(calendar.SiteDomain, ShouldEqual, basePage.SiteDomain)
+			So(calendar.BetaBannerEnabled, ShouldBeTrue)
+			So(calendar.Metadata.Title, ShouldEqual, metaTitle)
+			So(calendar.GlobalError.Title.LocaleKey, ShouldEqual, errTitleKey)
+			So(calendar.GlobalError.Message, ShouldEqual, err.Error())
 		})
 	})
 }

--- a/model/calendar.go
+++ b/model/calendar.go
@@ -36,6 +36,11 @@ type Sort struct {
 	Options []SortOption `json:"options"`
 }
 
+type GlobalError struct {
+	Title   coreModel.Localisation `json:"title"`
+	Message string                 `json:"message"`
+}
+
 type Calendar struct {
 	coreModel.Page
 
@@ -47,6 +52,7 @@ type Calendar struct {
 	Entries             []CalendarEntry         `json:"entries"`
 	KeywordSearch       coreModel.CompactSearch `json:"keyword_search"`
 	TotalSearchPosition int                     `json:"total_search_position,omitempty"`
+	GlobalError         GlobalError             `json:"global_error"`
 }
 
 func (calendar Calendar) FuncIsFilterSearchPresent() bool {


### PR DESCRIPTION
### What

When user input validation fails on a Release Calendar filter, for example an incorrect date is entered, an error message explaining the problem will be shown to the user.

<img width="1119" alt="Screenshot 2022-09-22 at 17 50 56" src="https://user-images.githubusercontent.com/912770/191807119-4a59a49d-6375-41ff-98de-bfd6e99989bf.png">

### How to review

- In a separate shell, run dp-design-system with `make debug`
- Run this frontend with `make debug`
- Visit the Release Calender
- Enter an incorrect date like 31/09/2022 or an out of bounds date like 01/01/1700
- Verify that the user sees an appropriate error message explaining the mistake
- Go back and correct the mistake
- Verify that the Release Calendar continues to work as expected with correct inputs.

### Who can review

Go / Frontend developers
