### PR TITLE
Ensure census only appears in query parameters when set

### DIFF
--- a/assets/templates/partials/calendar/hidden-inputs/census.tmpl
+++ b/assets/templates/partials/calendar/hidden-inputs/census.tmpl
@@ -1,13 +1,10 @@
 {{ range $type, $value := .ReleaseTypes }}
-  {{ if eq $value.Name "census" }}
+  {{ if and (eq $value.Name "census") $value.Checked }}
     <input
       type="hidden"
       name="{{ $value.Name}}"
-      {{ if $value.Checked }}
-        value="true"
-        checked
-      {{ else}}
-        value=""
-      {{ end }}>
+      value="true"
+      checked
+    >
   {{ end }}
 {{ end }}


### PR DESCRIPTION
### What

An empty `census=` appears in the URL when switching between release types (published/upcoming/cancelled). The census flag will now only appear in the URL when it is set via the filter "Show only: Census".

### How to review

- In a separate shell, run dp-design-system with `make debug`
- Run this frontend with `make debug`
- Visit the release calendar on http://localhost:27700/releasecalendar
- Switch between release types
- Verify that no `census=` appears in the URL
- Set the census filter under "Show only: Census"
- Verify that that `census=true` appears in the URL when switching between release types
- Clear the census filter under  "Show only: Census"
- Verify once again that no `census=` appears in the URL and doesn't appear when switching between release types

### Who can review

Anyone
