### PR TITLE
handle api datasets on release page

### DIFF
--- a/assets/templates/partials/release/contents/data.tmpl
+++ b/assets/templates/partials/release/contents/data.tmpl
@@ -20,4 +20,25 @@
       {{ end }}
     </li>
   {{ end }}
+  {{ range .RelatedAPIDatasets }}
+    <li class="ons-list__item">
+      <p>
+        {{/*
+          The Title is not always available for a link so re-use
+          the URI as the link text as a fallback.
+        */}}
+        {{ if and .URI .Title }}
+          <a href="{{ .URI }}">{{ .Title }}</a>
+        {{ else }}
+          <a href="{{ .URI }}">{{ .URI }}</a>
+        {{ end }}
+      </p>
+
+      {{ if .Summary }}
+        <p>
+          {{ .Summary }}
+        </p>
+      {{ end }}
+    </li>
+  {{ end }}
 </ul>

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -20,6 +20,7 @@ func createTableOfContents(
 	description model.ReleaseDescription,
 	relatedDocuments []model.Link,
 	relatedDatasets []model.Link,
+	relatedAPIDatasets []model.Link,
 	dateChanges []model.DateChange,
 	aboutTheData bool,
 ) coreModel.TableOfContents {
@@ -59,7 +60,7 @@ func createTableOfContents(
 		displayOrder = append(displayOrder, "publications")
 	}
 
-	if len(relatedDatasets) > 0 {
+	if len(relatedDatasets) > 0 || len(relatedAPIDatasets) > 0 {
 		sections["data"] = coreModel.ContentSection{
 			Current: false,
 			Title: coreModel.Localisation{
@@ -208,6 +209,7 @@ func CreateRelease(basePage coreModel.Page, release releasecalendar.Release, lan
 		result.Description,
 		result.RelatedDocuments,
 		result.RelatedDatasets,
+		result.RelatedAPIDatasets,
 		result.DateChanges,
 		result.AboutTheData,
 	)


### PR DESCRIPTION
### What

handle api datasets on release page
- add API datasets to table of contents mapper
- display API datasets in template

### Who can review

Anyone
