### PR TITLE
when tag is set to census, only display tag:census inside GTMJs

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -154,17 +154,31 @@ func createPreGTMJavaScript(title string, description model.ReleaseDescription) 
 	releaseStatus := "cancelled"
 	var censusTag string
 
+	releaseDate := helper.DateFormatYYYYMMDD(description.ReleaseDate)
+	releaseTime := helper.TimeFormat24h(description.ReleaseDate)
+
 	if description.Published {
 		releaseStatus = "published"
 	}
 
 	if description.Census2021 {
 		censusTag = "census"
+		return []template.JS{
+			template.JS(`dataLayer.push({
+				"analyticsOptOut": getUsageCookieValue(),
+				"gtm.whitelist": ["google","hjtc","lcl"],
+				"gtm.blacklist": ["customScripts","sp","adm","awct","k","d","j"],
+				"contentTitle": "` + title + `",
+				"release-status": "` + releaseStatus + `",
+				"release-date": "` + releaseDate + `",
+				"release-time": "` + releaseTime + `",
+				"release-date-status": "` + description.ProvisionalDate + `",
+				"next-release-date": "` + description.NextRelease + `",
+				"contact-name": "` + description.Contact.Name + `",
+				"tag": "` + censusTag + `"
+			});`),
+		}
 	}
-
-	releaseDate := helper.DateFormatYYYYMMDD(description.ReleaseDate)
-	releaseTime := helper.TimeFormat24h(description.ReleaseDate)
-
 	return []template.JS{
 		template.JS(`dataLayer.push({
 			"analyticsOptOut": getUsageCookieValue(),
@@ -177,7 +191,6 @@ func createPreGTMJavaScript(title string, description model.ReleaseDescription) 
 			"release-date-status": "` + description.ProvisionalDate + `",
 			"next-release-date": "` + description.NextRelease + `",
 			"contact-name": "` + description.Contact.Name + `",
-			"tag": "` + censusTag + `"
 		});`),
 	}
 }


### PR DESCRIPTION
What
https://trello.com/c/hdoRfYSq/1252-analytics-release-calendar-census-datalayer

One additional request, I've noticed on non-census pages the tag is visible as
tag:""

Would it be possible to not include the tag value in the dataLayer if there isn't a value to add. This will make it easier my side as otherwise I'll have to configure Google Tag Manager to manage an empty string, it's much easier if it wan't passed. Thanks!

How to review
This is now done with condition statement

Who can review
FD