### PR TITLE
Add renderror middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.254.1
 	github.com/ONSdigital/dp-healthcheck v1.6.1
 	github.com/ONSdigital/dp-net/v2 v2.11.0
-	github.com/ONSdigital/dp-renderer/v2 v2.4.0
+	github.com/ONSdigital/dp-renderer/v2 v2.5.0
 	github.com/ONSdigital/log.go/v2 v2.4.1
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0
@@ -17,6 +17,7 @@ require (
 
 require (
 	github.com/BurntSushi/toml v1.3.2 // indirect
+	github.com/ONSdigital/dp-cookies v0.4.0 // indirect
 	github.com/c2h5oh/datasize v0.0.0-20220606134207-859f65c6625b // indirect
 	github.com/fatih/color v1.15.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.254.1 h1:+wyakFWsEEZKm40dSxO5lEW9v8J5qlx3OA8GbMGDFqE=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.254.1/go.mod h1:OsW4tA+/WtyzhI2OzFESp3FJ2GphtVd9SCicDltSGDk=
+github.com/ONSdigital/dp-cookies v0.4.0 h1:B938xsFzj9OVM5yIRVVyteYYKjWN4Oz7i+u9+PEF8nk=
+github.com/ONSdigital/dp-cookies v0.4.0/go.mod h1:1xf96apIPNeV0WJs0UtKyM09laewXVUm/9bh84wFu7w=
 github.com/ONSdigital/dp-healthcheck v1.6.1 h1:YDAnxE2fI3G2hhGC42mKI/fRhAhIYmFZGQwQ/8M65M0=
 github.com/ONSdigital/dp-healthcheck v1.6.1/go.mod h1:FURB2RUJHw3lssamKtsGsrbu31ar9yhMSDYzG9vgSIo=
 github.com/ONSdigital/dp-mocking v0.10.1 h1:yEEglJ458kUztHlnGxhMiKhIr13gMYWYOBKFbCbp89M=
@@ -11,6 +13,8 @@ github.com/ONSdigital/dp-net/v2 v2.11.0 h1:XXst84GpXhBiyKoqLuohR7CvzrCBfSkq6Ysve
 github.com/ONSdigital/dp-net/v2 v2.11.0/go.mod h1:4T3GgoonNt2nZZJJer9cx7j/3XGJ1UhTp16flx+uDeA=
 github.com/ONSdigital/dp-renderer/v2 v2.4.0 h1:FKZdsu0+smrWHSGiDaCP77kqKVRJh3FDGyeLMctyLPU=
 github.com/ONSdigital/dp-renderer/v2 v2.4.0/go.mod h1:HezPp8MwD+w+iRcBYLpAy5HgzOIeTc8sVShjYyvVn9E=
+github.com/ONSdigital/dp-renderer/v2 v2.5.0 h1:PBsoTUVIej6xJy0wvy5vLCKaXhW2Y85vwBxWW/26dSg=
+github.com/ONSdigital/dp-renderer/v2 v2.5.0/go.mod h1:ZwG/qCwZhAubggp2c5tHBQK8tjuV0AE4ng3ZQGAXMXY=
 github.com/ONSdigital/log.go/v2 v2.4.1 h1:QAHQqtXgXx43OUTSebNAocVfN21RwrHzagN6zDAzwdo=
 github.com/ONSdigital/log.go/v2 v2.4.1/go.mod h1:hJTjxs9r8k49maNelGpL4SBWv8NG45vCKp15+6ce9bw=
 github.com/c2h5oh/datasize v0.0.0-20220606134207-859f65c6625b h1:6+ZFm0flnudZzdSE0JxlhR2hKnGPcNB35BjQf4RYQDY=

--- a/service/service.go
+++ b/service/service.go
@@ -12,8 +12,10 @@ import (
 	"github.com/ONSdigital/dp-frontend-release-calendar/handlers"
 	"github.com/ONSdigital/dp-frontend-release-calendar/routes"
 	render "github.com/ONSdigital/dp-renderer/v2"
+	"github.com/ONSdigital/dp-renderer/v2/middleware/renderror"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/mux"
+	"github.com/justinas/alice"
 )
 
 var (
@@ -71,8 +73,12 @@ func (svc *Service) Init(ctx context.Context, cfg *config.Config, serviceList *E
 
 	// Initialise router
 	r := mux.NewRouter()
+	middleware := []alice.Constructor{
+		renderror.Handler(clients.Render),
+	}
+	newAlice := alice.New(middleware...).Then(r)
 	routes.Setup(ctx, r, cfg, clients)
-	svc.Server = serviceList.GetHTTPServer(cfg.BindAddr, r)
+	svc.Server = serviceList.GetHTTPServer(cfg.BindAddr, newAlice)
 
 	return nil
 }


### PR DESCRIPTION
### What

- Add renderror middleware
- Update to version 2.5.0 of dp-renderer

### How to review

Run service and navigated to it directly e.g. `http://localhost:{bindAddr}` and navigate to a route that doesn't exist to generate a 404 page. You should see dp-renderer rendered error page. Or go to `releasecalendar` (without supporting services) and see the 500 page error

### Who can review

Anyone
