### PR TITLE
add error summary panel

### DIFF
--- a/assets/templates/calendar.tmpl
+++ b/assets/templates/calendar.tmpl
@@ -1,5 +1,8 @@
 <div class="ons-page__container ons-container release-calendar">
   <div class="ons-grid ons-u-ml-no">
+    {{ if gt (len .Error.ErrorItems) 0 }}
+      {{ template "partials/error-summary" .Error }}
+    {{ end }}
     <h1 class="ons-u-fs-xxxl ons-u-mt-m ons-u-mb-xl">{{ localise "ReleaseCalendarPageTitle" .Language 1 }}</h1>
     {{ if and .GlobalError.Title.LocaleKey .GlobalError.Message }}
       <div class="ons-grid__col ons-col-12@m ons-u-p-no ons-u-mb-xl">

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -341,6 +341,18 @@ func CreateReleaseCalendar(basePage coreModel.Page, params queryparams.Validated
 	if err != nil && errors.As(err, &queryparams.ErrInvalidDateInput{}) {
 		calendar.DateError.Show = true
 		calendar.DateError.Message = err.Error()
+
+		calendar.Error = coreModel.Error{
+			ErrorItems: []coreModel.ErrorItem{
+				{
+					URL: "#duration-error",
+					Description: coreModel.Localisation{
+						Text: err.Error(),
+					},
+				},
+			},
+			Language: calendar.Language,
+		}
 	}
 
 	calendar.AfterDate = coreModel.InputDate{


### PR DESCRIPTION
### What

This is to add a error summary panel to the top of the [release calendar](https://trello.com/c/XgpRj1rI).
Multiple errors and validation to come in later ticket.

There is also a `global-error` component that I've left in, as unsure if it was being used elsewhere.

### How to review

Sense check
You can add the below code to the `CreateReleaseCalendar` function in `mapper.go` to simulate errors.
```
data := coreModel.Error{
  ErrorItems: []coreModel.ErrorItem{
    {
    URL: "#duration-error",
      Description: coreModel.Localisation{
	      Text: "Error message 1",
      },
    },
    {
      URL: "#duration-error",
      Description: coreModel.Localisation{
	      Text: "Error message 2",
      },
    },
  },
  Language: calendar.Language,
}
calendar.Error = data
```

### Who can review

Anyone
