### PR TITLE
Feature/feature flag cache age from babbage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Run `make help` to see full list of make targets.
 | DEFAULT_MAXIMUM_LIMIT          | 100                       | The default maximum size of (number of search results on) a page                                                   |
 | DEFAULT_MAXIMUM_SEARCH_RESULTS | 1000                      | The default maximum number of search results that will be paged                                                    |
 | DEFAULT_SORT                   | "release_date_desc"       | The default sort order of search results                                                                           |
+| ENABLE_BABBAGE_CALCULATED_MAX_AGE | true                   | If true use Babbage to calculate max age for cache headers                                                         |
 | GRACEFUL_SHUTDOWN_TIMEOUT      | 5s                        | The graceful shutdown timeout in seconds (`time.Duration` format)                                                  |
 | HEALTHCHECK_CRITICAL_TIMEOUT   | 90s                       | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format) |
 | HEALTHCHECK_INTERVAL           | 30s                       | Time between self-healthchecks (`time.Duration` format)                                                            |

--- a/config/config.go
+++ b/config/config.go
@@ -10,22 +10,23 @@ import (
 )
 
 type Config struct {
-	APIRouterURL                string        `envconfig:"API_ROUTER_URL"`
-	BabbageMaxAgeKey            string        `envconfig:"BABBAGE_MAXAGE_KEY"`
-	BabbageURL                  string        `envconfig:"BABBAGE_URL"`
-	BindAddr                    string        `envconfig:"BIND_ADDR"`
-	Debug                       bool          `envconfig:"DEBUG"`
-	DefaultLimit                int           `envconfig:"DEFAULT_LIMIT"`
-	DefaultMaximumLimit         int           `envconfig:"DEFAULT_MAXIMUM_LIMIT"`
-	DefaultMaximumSearchResults int           `envconfig:"DEFAULT_MAXIMUM_SEARCH_RESULTS"`
-	DefaultSort                 string        `envconfig:"DEFAULT_SORT"`
-	GracefulShutdownTimeout     time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
-	HealthCheckCriticalTimeout  time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
-	HealthCheckInterval         time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
-	PatternLibraryAssetsPath    string        `envconfig:"PATTERN_LIBRARY_ASSETS_PATH"`
-	RoutingPrefix               string        `envconfig:"ROUTING_PREFIX"`
-	SiteDomain                  string        `envconfig:"SITE_DOMAIN"`
-	SupportedLanguages          []string      `envconfig:"SUPPORTED_LANGUAGES"`
+	APIRouterURL                  string        `envconfig:"API_ROUTER_URL"`
+	BabbageMaxAgeKey              string        `envconfig:"BABBAGE_MAXAGE_KEY"`
+	BabbageURL                    string        `envconfig:"BABBAGE_URL"`
+	BindAddr                      string        `envconfig:"BIND_ADDR"`
+	Debug                         bool          `envconfig:"DEBUG"`
+	DefaultLimit                  int           `envconfig:"DEFAULT_LIMIT"`
+	DefaultMaximumLimit           int           `envconfig:"DEFAULT_MAXIMUM_LIMIT"`
+	DefaultMaximumSearchResults   int           `envconfig:"DEFAULT_MAXIMUM_SEARCH_RESULTS"`
+	DefaultSort                   string        `envconfig:"DEFAULT_SORT"`
+	EnableBabbageCalculatedMaxAge bool          `envconfig:"ENABLE_BABBAGE_CALCULATED_MAX_AGE"`
+	GracefulShutdownTimeout       time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
+	HealthCheckCriticalTimeout    time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
+	HealthCheckInterval           time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
+	PatternLibraryAssetsPath      string        `envconfig:"PATTERN_LIBRARY_ASSETS_PATH"`
+	RoutingPrefix                 string        `envconfig:"ROUTING_PREFIX"`
+	SiteDomain                    string        `envconfig:"SITE_DOMAIN"`
+	SupportedLanguages            []string      `envconfig:"SUPPORTED_LANGUAGES"`
 }
 
 var cfg *Config
@@ -57,21 +58,22 @@ func get() (*Config, error) {
 	}
 
 	cfg = &Config{
-		APIRouterURL:                "http://localhost:23200/v1",
-		BabbageMaxAgeKey:            "",
-		BabbageURL:                  "http://localhost:8080",
-		BindAddr:                    ":27700",
-		Debug:                       false,
-		DefaultLimit:                10,
-		DefaultMaximumLimit:         100,
-		DefaultMaximumSearchResults: 1000,
-		DefaultSort:                 queryparams.RelDateDesc.String(),
-		GracefulShutdownTimeout:     5 * time.Second,
-		HealthCheckCriticalTimeout:  90 * time.Second,
-		HealthCheckInterval:         30 * time.Second,
-		RoutingPrefix:               "",
-		SiteDomain:                  "localhost",
-		SupportedLanguages:          []string{"en", "cy"},
+		APIRouterURL:                  "http://localhost:23200/v1",
+		BabbageMaxAgeKey:              "",
+		BabbageURL:                    "http://localhost:8080",
+		BindAddr:                      ":27700",
+		Debug:                         false,
+		DefaultLimit:                  10,
+		DefaultMaximumLimit:           100,
+		DefaultMaximumSearchResults:   1000,
+		DefaultSort:                   queryparams.RelDateDesc.String(),
+		EnableBabbageCalculatedMaxAge: true,
+		GracefulShutdownTimeout:       5 * time.Second,
+		HealthCheckCriticalTimeout:    90 * time.Second,
+		HealthCheckInterval:           30 * time.Second,
+		RoutingPrefix:                 "",
+		SiteDomain:                    "localhost",
+		SupportedLanguages:            []string{"en", "cy"},
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -39,17 +39,17 @@ func setStatusCode(req *http.Request, w http.ResponseWriter, err error) {
 }
 
 func setCacheHeader(ctx context.Context, w http.ResponseWriter, babbage BabbageAPI, uri, key string, cfg config.Config) {
-    if cfg.EnableBabbageCalculatedMaxAge {
-        maxAge, err := babbage.GetMaxAge(ctx, uri, key)
-        if err != nil {
-            // Do not cache
-            maxAge = defaultMaxAge
-            log.Warn(ctx,
-                fmt.Sprintf("Couldn't find max age from Babbage, using default %d sec", maxAge),
-                log.Data{"uri": uri, "err": err.Error()})
-        }
-        w.Header().Add("Cache-Control", fmt.Sprintf("public, max-age=%d", maxAge))
-    }
+	if cfg.EnableBabbageCalculatedMaxAge {
+		maxAge, err := babbage.GetMaxAge(ctx, uri, key)
+		if err != nil {
+			// Do not cache
+			maxAge = defaultMaxAge
+			log.Warn(ctx,
+				fmt.Sprintf("Couldn't find max age from Babbage, using default %d sec", maxAge),
+				log.Data{"uri": uri, "err": err.Error()})
+		}
+		w.Header().Add("Cache-Control", fmt.Sprintf("public, max-age=%d", maxAge))
+	}
 }
 
 // Release will load a release page


### PR DESCRIPTION
### What

The [release calendar](https://trello.com/c/rAVm9omn) currently uses babbage to calculate max age for its cache headers, this will be the case until `dp-legacy-cache-proxy` goes live. This puts this functionality behind a feature flag.

Flag name: `ENABLE_BABBAGE_CALCULATED_MAX_AGE`
Default: `true`

### How to review

Sense check.
Is everything working as expected?

### Who can review

Anyone
