### PR TITLE
fix/add-in-provisional-date

### DIFF
--- a/assets/templates/partials/calendar/items/list.tmpl
+++ b/assets/templates/partials/calendar/items/list.tmpl
@@ -27,7 +27,7 @@
         <span class="ons-u-fs-r--b">{{ localise "ReleaseDate" $.Language 1 }}:</span>
         <span>
           {{ if eq .PublicationState.SubType "provisional" }}
-              {{ dateTimeOnsDatePatternFormat .Description.ProvisionalDate $.Language }}
+              {{ .Description.ProvisionalDate $.Language }}
           {{ else }}
               {{ dateTimeOnsDatePatternFormat .Description.ReleaseDate $.Language }}
           {{ end }}


### PR DESCRIPTION
### What

This addresses an issue with the release date displaying when `SubType` is provisional, and should be provisional date.

### How to review

Goes with https://github.com/ONSdigital/dp-search-api/pull/279
Sense check.
Run locally

### Who can review

Anyone
