### PR TITLE
Fix/update browser tree in florence

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Run `make help` to see full list of make targets.
 | GRACEFUL_SHUTDOWN_TIMEOUT      | 5s                        | The graceful shutdown timeout in seconds (`time.Duration` format)                                                  |
 | HEALTHCHECK_CRITICAL_TIMEOUT   | 90s                       | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format) |
 | HEALTHCHECK_INTERVAL           | 30s                       | Time between self-healthchecks (`time.Duration` format)                                                            |
+| IS_PUBLISHING                  | false                     | Mode in which the service is running  										   |
 | PATTERN_LIBRARY_ASSETS_PATH    | ""                        | Pattern library location                                                                                           |
 | ROUTING_PREFIX                 | ""                        | Any routing prefix for the service                                                                                 |
 | SITE_DOMAIN                    | localhost                 |                                                                                                                    |

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	GracefulShutdownTimeout       time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckCriticalTimeout    time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
 	HealthCheckInterval           time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
+	IsPublishing                  bool          `envconfig:"IS_PUBLISHING"`
 	PatternLibraryAssetsPath      string        `envconfig:"PATTERN_LIBRARY_ASSETS_PATH"`
 	RoutingPrefix                 string        `envconfig:"ROUTING_PREFIX"`
 	SiteDomain                    string        `envconfig:"SITE_DOMAIN"`
@@ -71,6 +72,7 @@ func get() (*Config, error) {
 		GracefulShutdownTimeout:       5 * time.Second,
 		HealthCheckCriticalTimeout:    90 * time.Second,
 		HealthCheckInterval:           30 * time.Second,
+		IsPublishing:                  false,
 		RoutingPrefix:                 "",
 		SiteDomain:                    "localhost",
 		SupportedLanguages:            []string{"en", "cy"},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,6 +31,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)
+				So(cfg.IsPublishing, ShouldBeFalse)
 				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/c9ea175")
 				So(cfg.RoutingPrefix, ShouldEqual, "")
 				So(cfg.SiteDomain, ShouldEqual, "localhost")

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -70,7 +70,7 @@ func Release(cfg config.Config, rc RenderClient, api ReleaseCalendarAPI, babbage
 		}
 
 		basePage := rc.NewBasePageModel()
-		m := mapper.CreateRelease(basePage, *release, lang, cfg.CalendarPath(), homepageContent.ServiceMessage, homepageContent.EmergencyBanner)
+		m := mapper.CreateRelease(basePage, *release, lang, cfg.CalendarPath(), homepageContent.ServiceMessage, homepageContent.EmergencyBanner, cfg.IsPublishing)
 
 		setCacheHeader(ctx, w, babbage, releaseURI, cfg.BabbageMaxAgeKey, cfg)
 

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -199,7 +199,7 @@ func createPreGTMJavaScript(title string, description model.ReleaseDescription) 
 	}
 }
 
-func CreateRelease(basePage coreModel.Page, release releasecalendar.Release, lang, path, serviceMessage string, emergencyBannerContent zebedee.EmergencyBanner) model.Release {
+func CreateRelease(basePage coreModel.Page, release releasecalendar.Release, lang, path, serviceMessage string, emergencyBannerContent zebedee.EmergencyBanner, isPublishing bool) model.Release {
 	result := model.Release{
 		Page:     basePage,
 		Markdown: release.Markdown,
@@ -223,6 +223,7 @@ func CreateRelease(basePage coreModel.Page, release releasecalendar.Release, lan
 			ProvisionalDate:    release.Description.ProvisionalDate,
 		},
 	}
+	result.FeatureFlags.IsPublishing = isPublishing
 	result.Language = lang
 	result.Type = "releaseCalendar"
 	result.ServiceMessage = serviceMessage
@@ -314,6 +315,7 @@ func CreateReleaseCalendar(basePage coreModel.Page, params queryparams.Validated
 	calendar := model.Calendar{
 		Page: basePage,
 	}
+	calendar.FeatureFlags.IsPublishing = cfg.IsPublishing
 	calendar.Language = lang
 	calendar.Type = "releaseCalendar"
 	calendar.URI = "/releasecalendar"

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -133,8 +133,9 @@ func TestUnitMapper(t *testing.T) {
 				URI:         emergencyBannerURI,
 				LinkText:    emergencyBannerLinkText,
 			}
-			release := CreateRelease(basePage, releaseResponse, lang, "/prefix/releasecalendar", serviceMessage, bannerData)
+			release := CreateRelease(basePage, releaseResponse, lang, "/prefix/releasecalendar", serviceMessage, bannerData, true)
 
+			So(release.FeatureFlags.IsPublishing, ShouldBeTrue)
 			So(release.PatternLibraryAssetsPath, ShouldEqual, basePage.PatternLibraryAssetsPath)
 			So(release.SiteDomain, ShouldEqual, basePage.SiteDomain)
 			So(release.BetaBannerEnabled, ShouldBeTrue)
@@ -299,6 +300,7 @@ func TestReleaseCalendarMapper(t *testing.T) {
 
 			calendar := CreateReleaseCalendar(basePage, params, releaseResponse, cfg, lang, serviceMessage, bannerData, nil)
 
+			So(calendar.FeatureFlags.IsPublishing, ShouldBeFalse)
 			So(calendar.PatternLibraryAssetsPath, ShouldEqual, basePage.PatternLibraryAssetsPath)
 			So(calendar.SiteDomain, ShouldEqual, basePage.SiteDomain)
 			So(calendar.BetaBannerEnabled, ShouldBeTrue)


### PR DESCRIPTION
### What

The browser tree within Florence is not updating as publishing officers would expect, when editing 'release' pages - [slack thread](https://onswebsite.slack.com/archives/C1BK8ES15/p1715855493684599)
To fix - an environment config needs to be passed to the page mapper which then will render the appropriate helper function AKA these changes - ✅ [trello ticket](https://trello.com/c/oYcuJiWp/2185-release-calendar-isnt-updating-browse-tree-in-florence)

### How to review

Sense check
L👀k at the image
__Or__
- Run this app on this branch `make debug IS_PUBLISHING=true`
- Port forward on the api router to sandbox (if you'd like to see data)
- Run the `dp-design-system` so look and feel are good 👍 

#### Image 
<img width="812" alt="rendering publishing helper func" src="https://github.com/ONSdigital/dp-frontend-release-calendar/assets/19624419/061100b1-792d-446a-afce-2349d5967518">

### Who can review

!me
