### PR TITLE
DIS-1140 Release calendar provision date

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -267,7 +267,7 @@ func CreateRelease(cfg config.Config, basePage coreModel.Page, release releaseca
 	result.PreGTMJavaScript = createPreGTMJavaScript(result.Metadata.Title, result.Description)
 
 	if !result.Description.Finalised && result.Description.ProvisionalDate == "" {
-		result.Description.ProvisionalDate = helper.DateTimeOnsDatePatternFormat(result.Description.ReleaseDate, result.Language )
+		result.Description.ProvisionalDate = helper.DateTimeOnsDatePatternFormat(result.Description.ReleaseDate, result.Language)
 	}
 	return result
 }


### PR DESCRIPTION
### What

Used helper function to turn initial provisional date into readable format

### How to review

LGTM / Run publishing stack + dp-frontend-release-calendar + dp-release-calendar-api, make a release calendar entry and check that the provisional release date is shown if finalised is unchecked and it's not a timestamp and something like "31 July 2024 9:30am".

### Who can review

Anyone