### PR TITLE
Feature/prerelease access section

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -335,3 +335,11 @@ one = "Enter a released before year that is later than"
 [ClearAll]
 description = "Clear all"
 one = "Clirio'r cyfan"
+
+[PreReleaseAccessListExplanation1]
+description = "Explanation of what 'Pre-release Access' means"
+one = "The phrase 'Pre-release Access' refers to the practice whereby official statistics in their final form, and any accompanying written commentary, are made available to an eligible person in advance of their publication. The rules and principles which govern pre-release access are featured within the Pre-release Access to Official Statistics Order 2008."
+
+[PreReleaseAccessListExplanation2]
+description = "Who gets pre-release access and when"
+one = "Besides ONS staff, the following persons are given pre-release access by the period indicated before release."

--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -160,6 +160,10 @@ one = "Newidiadau i ddyddiad y datganiad hwn"
 description = "About the data"
 one = "Ynglŷn â'r data"
 
+[ReleaseSectionPreReleaseAccessList]
+description = "Pre-release access list"
+one = "Pre-release access list"
+
 [ReleaseSectionMoreOnThisTopic]
 description = "More on this topic"
 one = "Mwy am y pwnc hwn"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -335,3 +335,11 @@ one = "Enter a released before year that is later than"
 [ClearAll]
 description = "Clear all"
 one = "Clear all"
+
+[PreReleaseAccessListExplanation1]
+description = "Explanation of what 'Pre-release Access' means"
+one = "The phrase 'Pre-release Access' refers to the practice whereby official statistics in their final form, and any accompanying written commentary, are made available to an eligible person in advance of their publication. The rules and principles which govern pre-release access are featured within the Pre-release Access to Official Statistics Order 2008."
+
+[PreReleaseAccessListExplanation2]
+description = "Who gets pre-release access and when"
+one = "Besides ONS staff, the following persons are given pre-release access by the period indicated before release."

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -160,6 +160,10 @@ one = "Changes to this release date"
 description = "About the data"
 one = "About the data"
 
+[ReleaseSectionPreReleaseAccessList]
+description = "Pre-release access list"
+one = "Pre-release access list"
+
 [ReleaseSectionMoreOnThisTopic]
 description = "More on this topic"
 one = "More on this topic"

--- a/assets/templates/partials/release/contents/body.tmpl
+++ b/assets/templates/partials/release/contents/body.tmpl
@@ -17,6 +17,8 @@
         {{ template "partials/release/contents/date-changes" $release }}
       {{ else if eq $id "aboutthedata" }}
         {{ template "partials/release/contents/about-the-data" $release }}
+      {{ else if eq $id "prereleaseaccesslist" }}
+        {{ template "partials/release/contents/prerelease-access-list" $release }}
       {{ else if eq $id "moreonthistopic" }}
         {{ template "partials/release/contents/more-on-this-topic" $release }}
       {{ else if eq $id "methodology" }}

--- a/assets/templates/partials/release/contents/prerelease-access-list.tmpl
+++ b/assets/templates/partials/release/contents/prerelease-access-list.tmpl
@@ -1,16 +1,6 @@
 <div>
-  <p>
-    The phrase 'Pre-release Access' refers to the practice whereby official statistics
-    in their final form, and any accompanying written commentary, are made available to
-    an eligible person in advance of their publication. The rules and principles
-    which govern pre-release access are featured within the Pre-release Access to
-    Official Statistics Order 2008.
-  </p>
-
-  <p>
-    Besides ONS staff, the following persons are given pre-release access by
-    the period indicated before release.
-  </p>
+  <p>{{ localise "PreReleaseAccessListExplanation1" .Language 1 }}</p>
+  <p>{{ localise "PreReleaseAccessListExplanation2" .Language 1 }}</p>
   {{ range $markdown := .Markdown }}
   <div class="ons-u-mb-l">
     {{ $markdown | safeHTML }}

--- a/assets/templates/partials/release/contents/prerelease-access-list.tmpl
+++ b/assets/templates/partials/release/contents/prerelease-access-list.tmpl
@@ -1,0 +1,19 @@
+<div>
+  <p>
+    The phrase 'Pre-release Access' refers to the practice whereby official statistics
+    in their final form, and any accompanying written commentary, are made available to
+    an eligible person in advance of their publication. The rules and principles
+    which govern pre-release access are featured within the Pre-release Access to
+    Official Statistics Order 2008.
+  </p>
+
+  <p>
+    Besides ONS staff, the following persons are given pre-release access by
+    the period indicated before release.
+  </p>
+  {{ range $markdown := .Markdown }}
+  <div class="ons-u-mb-l">
+    {{ $markdown | safeHTML }}
+  </div>
+  {{ end }}
+</div>

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -24,7 +24,7 @@ func TestUnitMapper(t *testing.T) {
 
 		releaseResponse := releasecalendar.Release{
 			URI:      "/releases/test",
-			Markdown: []string{"markdown1", "markdown 2"},
+			Markdown: []string{"<p>markdown1</p>\n", "<p>markdown 2</p>\n"},
 			RelatedDocuments: []releasecalendar.Link{
 				{
 					Title:   "Document 1",


### PR DESCRIPTION
### What

[This](https://jira.ons.gov.uk/browse/DIS-1040) adds a pre release section to release pages when markdown is present in results.

### How to review

Grab this branch
Change APIRouterURL to `https://api.dp.aws.onsdigital.uk/v1` in config
Run `make debug`
Run search stack
Go to http://localhost:27700/releases/ukconsumerpriceindicesjan2016

**Table of Contents**
![image](https://github.com/user-attachments/assets/709a2209-9eb7-4ae8-9ace-7c8eea3e6fb9)

**Pre-release access list section**
![image](https://github.com/user-attachments/assets/4eba5951-0f8c-4690-abc9-ebcf3b06ab3e)


### Who can review

Frontend
