### PR TITLE
feature/remove phone header if blank

### DIFF
--- a/assets/templates/partials/release/contents/contact-details.tmpl
+++ b/assets/templates/partials/release/contents/contact-details.tmpl
@@ -13,12 +13,14 @@
     </a>
   </p>
 
-  <h3 class="ons-u-mb-no ons-u-fs-r--b">
-    {{- localise "ReleaseSubsectionPhone" .Language 1 -}}
-  </h3>
-  <p>
-    <a href="tel:{{ .Description.Contact.Telephone }}">
-      {{- .Description.Contact.Telephone -}}
-    </a>
-  </p>
+  {{ if .Description.Contact.Telephone }}
+    <h3 class="ons-u-mb-no ons-u-fs-r--b">
+      {{- localise "ReleaseSubsectionPhone" .Language 1 -}}
+    </h3>
+    <p>
+      <a href="tel:{{ .Description.Contact.Telephone }}">
+        {{- .Description.Contact.Telephone -}}
+      </a>
+    </p>
+  {{ end }}
 </div>


### PR DESCRIPTION
### What

This conditionally removes the. phone header from contact details if blank

### How to review

- change `APIRouterURL` in config to `https://api.dp-prod.aws.onsdigital.uk/v1`
- run `make debug`
- goto:
   - http://localhost:27700/releases/experiencesofnhshealthcareservicesinengland27february2025 (appears)
![image](https://github.com/user-attachments/assets/6e47bf39-e8f4-4f0e-8928-6676bd56f2ab)

   - http://localhost:27700/releases/economicactivityandsocialchangeintheukrealtimeindicators27february2025 (doesn't appear)
![image](https://github.com/user-attachments/assets/97cb48fc-7e7c-438a-bb07-d7cf9aa91c5b)




### Who can review

Frontend
