### PR TITLE
Fix rss date format to rfc3339

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -451,7 +451,7 @@ func createRSSFeed(ctx context.Context, w http.ResponseWriter, r *http.Request, 
 	feed.Items = []*feeds.Item{}
 	for i := range releases.Releases {
 		release := &releases.Releases[i]
-		date, parseErr := time.Parse("2006-01-02T15:04:05.000Z", release.Description.ReleaseDate)
+		date, parseErr := time.Parse(time.RFC3339, release.Description.ReleaseDate)
 		if parseErr != nil {
 			return fmt.Errorf("error parsing time: %s", parseErr)
 		}


### PR DESCRIPTION
### What

Corrected the date parser to use RFC3339, what we use in search

### How to review

Portforward to staging api router. 
Run app
Hit localhost:27700/releasecalendar?rss - it will now give a result and not 502

### Who can review

Not me. 